### PR TITLE
Add a recursion limit to Exif

### DIFF
--- a/raves_metadata/src/exif/ifd.rs
+++ b/raves_metadata/src/exif/ifd.rs
@@ -87,13 +87,14 @@ pub fn parse_ifd(input: &mut Stream) -> Result<(Ifd, NextIfdPointer), ExifFatalE
         })
         .flat_map(|(ifd_group, ptr)| {
             // skip to the IFD in the original blob
-            let blob = &input.state.blob[ptr as usize..];
+            let new_ifd_input = &input.state.blob[ptr as usize..];
 
+            // construct the next state
             let state = &mut Stream {
-                input,
+                input: new_ifd_input,
                 state: State {
                     endianness: &endianness,
-                    blob,
+                    blob: input.state.blob,
                     current_ifd: ifd_group,
                 },
             };

--- a/raves_metadata/src/exif/value.rs
+++ b/raves_metadata/src/exif/value.rs
@@ -297,6 +297,8 @@ mod tests {
                     current_ifd: IfdGroup::_0,
                     endianness: &WinnowEndianness::Little,
                     blob: &backing_bytes,
+                    recursion_ct: 0,
+                    recursion_stack: Default::default(),
                 }
             }),
             Err(ExifFieldError::FieldUnknownType { got: 0_u16 })
@@ -327,6 +329,8 @@ mod tests {
                     endianness: &WinnowEndianness::Little,
                     blob: &backing_bytes,
                     current_ifd: IfdGroup::_0,
+                    recursion_ct: 0,
+                    recursion_stack: Default::default(),
                 }
             }),
             Ok(Field {


### PR DESCRIPTION
Prevent stack overflow due to recursion. 

## Changes

- Fix potential error when parsing sub-IFDs
- Add fields about recursion to IFD parser's `Stream`/`State`
- Check for recursion after the "recursion limit", a constant (currently set to 32) in the `ifd` module
- Ensure that IFDs do not self-recurse

## Testing

Added a couple of tests. One for IFD parsing itself, and another for the new helper function I made to set the `State`'s new recursion when the `parse_ifd` function is called.

Fixes #11 