### PR TITLE
Add `new` method to `MetadataProvider` trait

### DIFF
--- a/raves_metadata/src/lib.rs
+++ b/raves_metadata/src/lib.rs
@@ -38,6 +38,9 @@
 
 #![forbid(unsafe_code)]
 
+use core::fmt::Debug;
+use std::error::Error;
+
 use iptc::{Iptc, error::IptcError};
 
 use crate::{
@@ -53,7 +56,15 @@ pub mod xmp;
 /// A media file with support for various metadata formats.
 ///
 /// Each file format is a "provider" - it'll yield its metdata through parsing.
-pub trait MetadataProvider {
+pub trait MetadataProvider<'input>: Clone + Debug + Sized + Send + Sync {
+    /// An error that can occur when calling [`MetadataProvider::new`].
+    type ConstructionError: Clone + Debug + PartialEq + PartialOrd + Error + Sized + Send + Sync;
+
+    /// Parses a media file for its metadata.
+    fn new(
+        input: &'input impl AsRef<[u8]>,
+    ) -> Result<Self, <Self as MetadataProvider<'input>>::ConstructionError>;
+
     /// Parses `self` to find any Exif metadata.
     ///
     /// This returns `None` if Exif isn't supported, or if the file has no Exif

--- a/raves_metadata/src/providers/heic.rs
+++ b/raves_metadata/src/providers/heic.rs
@@ -9,25 +9,29 @@ use crate::{
     MetadataProvider,
     exif::{Exif, error::ExifFatalError},
     iptc::{Iptc, error::IptcError},
-    providers::shared::bmff::heif::{HeifLike, HeifLikeConstructionError},
+    providers::shared::bmff::heif::HeifLike,
     xmp::{Xmp, error::XmpError},
 };
 
 const SUPPORTED_HEIC_BRANDS: &[[u8; 4]] = &[*b"heic"];
 
 /// A HEIC file.
+#[derive(Clone, Debug, PartialEq, PartialOrd, Hash)]
 pub struct Heic<'input> {
     heic_like: HeifLike<'input>,
 }
 
-impl<'input> Heic<'input> {
-    /// Constructs a HEIC representation from the given input blob.
-    pub fn new(mut input: &'input [u8]) -> Result<Self, HeifLikeConstructionError> {
-        HeifLike::new(&mut input, SUPPORTED_HEIC_BRANDS).map(|heic_like| Heic { heic_like })
-    }
-}
+impl<'input> MetadataProvider<'input> for Heic<'input> {
+    type ConstructionError = <HeifLike<'input> as MetadataProvider<'input>>::ConstructionError;
 
-impl<'input> MetadataProvider for Heic<'input> {
+    /// Constructs a HEIC representation from the given input blob.
+    fn new(
+        input: &'input impl AsRef<[u8]>,
+    ) -> Result<Self, <Self as MetadataProvider<'input>>::ConstructionError> {
+        HeifLike::parse(&mut input.as_ref(), SUPPORTED_HEIC_BRANDS)
+            .map(|heic_like| Heic { heic_like })
+    }
+
     fn exif(&self) -> Option<Result<Exif, ExifFatalError>> {
         self.heic_like.exif()
     }
@@ -58,7 +62,7 @@ mod tests {
         let blob: &[u8] = include_bytes!("../../assets/providers/heic/C034.heic");
 
         // parse it into heic
-        let file: Heic = Heic::new(blob).expect("parse as heic");
+        let file: Heic = Heic::new(&blob).expect("parse as heic");
 
         // it should only have exif
         assert!(file.iptc().is_none(), "iptc unsupported");

--- a/raves_metadata/src/providers/shared/bmff/heif/mod.rs
+++ b/raves_metadata/src/providers/shared/bmff/heif/mod.rs
@@ -34,13 +34,14 @@ mod pitm;
 mod search;
 
 /// A HEIF-like file.
+#[derive(Clone, Debug, PartialEq, PartialOrd, Hash)]
 pub struct HeifLike<'input> {
     exif: Option<&'input [u8]>,
     xmp: Option<&'input [u8]>,
 }
 
 impl HeifLike<'_> {
-    pub fn new<'input>(
+    pub fn parse<'input>(
         input: &mut &'input [u8],
         supported_ftyp_entries: &[[u8; 4]],
     ) -> Result<HeifLike<'input>, HeifLikeConstructionError> {
@@ -48,7 +49,21 @@ impl HeifLike<'_> {
     }
 }
 
-impl<'input> MetadataProvider for HeifLike<'input> {
+impl<'input> MetadataProvider<'input> for HeifLike<'input> {
+    type ConstructionError = HeifLikeConstructionError;
+
+    /// DO NOT CALL THIS.
+    ///
+    /// Call `Self::parse` instead.
+    fn new(
+        _input: &'input impl AsRef<[u8]>,
+    ) -> Result<Self, <Self as MetadataProvider<'input>>::ConstructionError> {
+        unreachable!(
+            "this is an implementation detail that's effectively private. \
+            please call the `parse` method instead."
+        )
+    }
+
     fn exif(&self) -> Option<Result<Exif, ExifFatalError>> {
         self.exif.map(|mut exif| crate::Exif::new(&mut exif))
     }

--- a/raves_metadata/src/providers/webp/chunk.rs
+++ b/raves_metadata/src/providers/webp/chunk.rs
@@ -1,6 +1,6 @@
 use winnow::{ModalResult, Parser as _, binary::le_u32, error::ContextError, token::take};
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Hash)]
 pub struct RiffChunk {
     pub fourcc: [u8; 4],
     pub len: u32,

--- a/raves_metadata/src/providers/webp/error.rs
+++ b/raves_metadata/src/providers/webp/error.rs
@@ -1,7 +1,36 @@
 #[derive(Clone, Debug, PartialEq, PartialOrd, Hash)]
-pub enum WebpCreationError {
+pub enum WebpConstructionError {
+    /// Failed to find the required WebP header.
     NoHeader,
+
+    /// No chunks were found in the file.
     NoChunks,
 
+    /// The extended header was malformed.
+    ///
+    /// It's required to find metadata, so lacking it means we're unable to
+    /// continue parsing the file.
     MalformedExtendedHeader,
 }
+
+impl core::fmt::Display for WebpConstructionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WebpConstructionError::NoHeader => {
+                f.write_str("The required WebP header was not found.")
+            }
+
+            WebpConstructionError::NoChunks => f.write_str(
+                "The WebP file didn't contain any chunks. \
+                Can't continue parsing.",
+            ),
+
+            WebpConstructionError::MalformedExtendedHeader => f.write_str(
+                "The WebP file didn't contain a usable extended header. \
+                Can't continue parsing.",
+            ),
+        }
+    }
+}
+
+impl core::error::Error for WebpConstructionError {}

--- a/raves_metadata/src/providers/webp/header.rs
+++ b/raves_metadata/src/providers/webp/header.rs
@@ -5,6 +5,7 @@ use winnow::{
     token::literal,
 };
 
+#[derive(Clone, Debug, PartialEq, PartialOrd, Hash)]
 pub struct WebpFileHeader {
     /// Represents how large the file is.
     ///


### PR DESCRIPTION
It felt weird that all of the providers had their own special way to provide data.

This PR fixes that by adding a `new` method on the crate's main trait.

## Changes

- Creates `MetadataProvider::new`
- Moves each of the providers' constructors to use the trait's instead!

## Impacts

- New users would more easily understand how to use the parser :)
- Increases consistency in the interface
- Makes `MetadataProvider` not dyn-compatible (object-safe) :(