### PR TITLE
Remove lazy parsing (in other words, make metadata lockless)

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -19,21 +19,6 @@ Don't add dependencies to this crate unless required for manual parsing. System/
 
 This crate provides runtime logging to a "logger implementation." I'd usually prefer `tracing`, but it's slower, and we can't even use its instrumentation due to the `syn` requirement. `log` has no dependencies.
 
-#### `parking_lot`
-
-Implements a poison-free `RwLock`.
-
-Unfortunately, `parking_lot` adds quite a few dependencies:
-
-- `lock_api`: primitives for defining reusable lock types.
-  - `scope_guard`: runs a closure when things fall out of scope, even during an unwinding panic.
-- `parking_lot_core`: the reusable "thread parking" parts of `parking_lot`. we uhh. don't use it
-  - `cfg_if`: simplifies `cfg` usage for feature flags and other nonsense
-  - `libc`: it's libc
-  - `smallvec`: vecs that are stack-alloc'd when small, but heap-alloc'd when big
-
-On the other hand, we can completely replace this dependency if (when?) [Rust's `sync_nonpoison` feature](https://github.com/rust-lang/rust/issues/134645) stabilizes. So, hopefully that's soon.
-
 #### `xmltree`
 
 Parses XML, because that's a little outta scope at the moment.

--- a/raves_metadata/CHANGELOG.typ
+++ b/raves_metadata/CHANGELOG.typ
@@ -2,13 +2,24 @@
 
 This file is ordered from newest to oldest.
 
+== v0.1.0
+
+- Remove locking on inner metadata types
+  - This change is in preparation for write support; we'll use objects less like a resource and more like a metadata "snapshot".
+  - When it comes time to write, we'll compare length and hashes to know if we need to reparse first.
+  - Also, making this change allows us to remove the `parking_lot` dependency, which is great!
+- Remove lazy metadata parsing
+  - Eager parsing seems to be the same amount of "efficient" for most files, as we already gotta parse them anyway!
+- Simplify API (one `MetadataProvider`)
+  - In other words, there's no longer a `MetadataProviderRaw`!
+
 == v0.0.4
 
 Add support for the GIF file format.
 
 == v0.0.3
 
-Use the newest version of `raves_metdata_types`.
+Use the newest version of `raves_metadata_types`.
 
 == v0.0.2
 

--- a/raves_metadata/Cargo.toml
+++ b/raves_metadata/Cargo.toml
@@ -17,7 +17,6 @@ rust-version.workspace = true
 
 [dependencies]
 log = "0.4.27"
-parking_lot = "0.12.4"
 raves_metadata_types = { version = "0.0.2", path = "../raves_metadata_types" }
 winnow = "0.7.11"
 

--- a/raves_metadata/src/lib.rs
+++ b/raves_metadata/src/lib.rs
@@ -131,7 +131,7 @@ pub trait MetadataProvider:
     ///
     /// This will return an error if the file's metadata is malformed or
     /// corrupted.
-    fn exif(&self) -> &Option<Result<Exif, ExifFatalError>>;
+    fn exif(&self) -> Option<Result<&Exif, &ExifFatalError>>;
 
     /// Parses `self` to find any IPTC metadata.
     ///
@@ -144,13 +144,13 @@ pub trait MetadataProvider:
     ///
     /// This will return an error if the file's metadata is malformed or
     /// corrupted.
-    fn iptc(&self) -> &Option<Result<Iptc, IptcError>> {
+    fn iptc(&self) -> Option<Result<&Iptc, &IptcError>> {
         log::error!(
             "Attempted to parse for IPTC, but IPTC IIC isn't \
             implemented in this library yet. \
             Returning None..."
         );
-        &None
+        None
     }
 
     /// Parses `self` to find any XMP metadata.
@@ -162,7 +162,7 @@ pub trait MetadataProvider:
     ///
     /// This will return an error if the file's metadata is malformed or
     /// corrupted.
-    fn xmp(&self) -> &Option<Result<Xmp, XmpError>>;
+    fn xmp(&self) -> Option<Result<&Xmp, &XmpError>>;
 
     /// Indicates whether the given input matches the magic number of this
     /// provider.

--- a/raves_metadata/src/magic_number.rs
+++ b/raves_metadata/src/magic_number.rs
@@ -153,13 +153,13 @@ macro_rules! generate {
             /// For more information, see:
             ///
             /// [`MetadataProvider::exif`][`crate::MetadataProvider::exif`]
-            pub fn exif(&self) -> &Option<Result<crate::Exif, crate::ExifFatalError>> {
+            pub fn exif(&self) -> Option<Result<&crate::Exif, &crate::ExifFatalError>> {
                 match self {
                     $(
                         Self::$variant(maybe_inner) => {
                             let Ok(inner) = maybe_inner else {
                                 ::log::error!("The inner provider is an error, not `Ok`. Cannot get metadata.");
-                                return &None;
+                                return None;
                             };
                             <$provider_ty as $crate::MetadataProvider>::exif(inner)
                         },
@@ -173,13 +173,13 @@ macro_rules! generate {
             /// For more information, see:
             ///
             /// [`MetadataProvider::iptc`][`crate::MetadataProvider::iptc`]
-            pub fn iptc(&self) -> &Option<Result<crate::Iptc, crate::IptcError>> {
+            pub fn iptc(&self) -> Option<Result<&crate::Iptc, &crate::IptcError>> {
                 match self {
                     $(
                         Self::$variant(maybe_inner) => {
                             let Ok(inner) = maybe_inner else {
                                 ::log::error!("The inner provider is an error, not `Ok`. Cannot get metadata.");
-                                return &None;
+                                return None;
                             };
                             <$provider_ty as $crate::MetadataProvider>::iptc(inner)
                         },
@@ -193,13 +193,13 @@ macro_rules! generate {
             /// For more information, see:
             ///
             /// [`MetadataProvider::xmp`][`crate::MetadataProvider::xmp`]
-            pub fn xmp(&self) -> &Option<Result<crate::Xmp, crate::XmpError>> {
+            pub fn xmp(&self) -> Option<Result<&crate::Xmp, &crate::XmpError>> {
                 match self {
                     $(
                         Self::$variant(maybe_inner) => {
                             let Ok(inner) = maybe_inner else {
                                 ::log::error!("The inner provider is an error, not `Ok`. Cannot get metadata.");
-                                return &None;
+                                return None;
                             };
                             <$provider_ty as $crate::MetadataProvider>::xmp(inner)
                         },

--- a/raves_metadata/src/magic_number.rs
+++ b/raves_metadata/src/magic_number.rs
@@ -153,13 +153,13 @@ macro_rules! generate {
             /// For more information, see:
             ///
             /// [`MetadataProvider::exif`][`crate::MetadataProvider::exif`]
-            pub fn exif(&self) -> Option<Result<std::sync::Arc<parking_lot::RwLock<crate::Exif>>, crate::ExifFatalError>> {
+            pub fn exif(&self) -> &Option<Result<crate::Exif, crate::ExifFatalError>> {
                 match self {
                     $(
                         Self::$variant(maybe_inner) => {
                             let Ok(inner) = maybe_inner else {
                                 ::log::error!("The inner provider is an error, not `Ok`. Cannot get metadata.");
-                                return None;
+                                return &None;
                             };
                             <$provider_ty as $crate::MetadataProvider>::exif(inner)
                         },
@@ -173,13 +173,13 @@ macro_rules! generate {
             /// For more information, see:
             ///
             /// [`MetadataProvider::iptc`][`crate::MetadataProvider::iptc`]
-            pub fn iptc(&self) -> Option<Result<std::sync::Arc<parking_lot::RwLock<crate::Iptc>>, crate::IptcError>> {
+            pub fn iptc(&self) -> &Option<Result<crate::Iptc, crate::IptcError>> {
                 match self {
                     $(
                         Self::$variant(maybe_inner) => {
                             let Ok(inner) = maybe_inner else {
                                 ::log::error!("The inner provider is an error, not `Ok`. Cannot get metadata.");
-                                return None;
+                                return &None;
                             };
                             <$provider_ty as $crate::MetadataProvider>::iptc(inner)
                         },
@@ -193,13 +193,13 @@ macro_rules! generate {
             /// For more information, see:
             ///
             /// [`MetadataProvider::xmp`][`crate::MetadataProvider::xmp`]
-            pub fn xmp(&self) -> Option<Result<std::sync::Arc<parking_lot::RwLock<crate::Xmp>>, crate::XmpError>> {
+            pub fn xmp(&self) -> &Option<Result<crate::Xmp, crate::XmpError>> {
                 match self {
                     $(
                         Self::$variant(maybe_inner) => {
                             let Ok(inner) = maybe_inner else {
                                 ::log::error!("The inner provider is an error, not `Ok`. Cannot get metadata.");
-                                return None;
+                                return &None;
                             };
                             <$provider_ty as $crate::MetadataProvider>::xmp(inner)
                         },

--- a/raves_metadata/src/providers/avif.rs
+++ b/raves_metadata/src/providers/avif.rs
@@ -29,12 +29,12 @@ impl MetadataProvider for Avif {
             .map(|heic_like| Avif { heic_like })
     }
 
-    fn exif(&self) -> &Option<Result<crate::exif::Exif, crate::exif::error::ExifFatalError>> {
-        &self.heic_like.exif
+    fn exif(&self) -> Option<Result<&crate::exif::Exif, &crate::exif::error::ExifFatalError>> {
+        self.heic_like.exif.as_ref().map(|r| r.as_ref())
     }
 
-    fn xmp(&self) -> &Option<Result<crate::xmp::Xmp, crate::xmp::error::XmpError>> {
-        &self.heic_like.xmp
+    fn xmp(&self) -> Option<Result<&crate::xmp::Xmp, &crate::xmp::error::XmpError>> {
+        self.heic_like.xmp.as_ref().map(|r| r.as_ref())
     }
 }
 
@@ -61,7 +61,6 @@ mod tests {
         // construct the xmp
         let xmp = file
             .xmp()
-            .clone()
             .expect("XMP is supported + provided in file")
             .expect("XMP should be present");
 
@@ -79,15 +78,14 @@ mod tests {
         );
 
         // parse exif
-        let mut exif = file
+        let exif = file
             .exif()
-            .clone()
             .expect("exif should be supported")
             .expect("exif should be found");
 
         // ensure only one ifd
         assert_eq!(exif.ifds.len(), 1, "should only be one ifd");
-        let ifd: Ifd = exif.ifds.remove(0);
+        let ifd: Ifd = exif.ifds[0].clone();
 
         // grab same gimp timestamp above
         let gimp_timestamp: Vec<Field> = ifd
@@ -123,7 +121,6 @@ mod tests {
 
         let xmp = file
             .xmp()
-            .clone()
             .expect("XMP is supported + provided in file")
             .expect("XMP should be present");
 
@@ -143,14 +140,13 @@ mod tests {
             },
         );
 
-        let mut exif = file
+        let exif = file
             .exif()
-            .clone()
             .expect("exif should be supported")
             .expect("exif should be found");
 
         assert_eq!(exif.ifds.len(), 1, "should only be one ifd");
-        let ifd: Ifd = exif.ifds.remove(0);
+        let ifd: Ifd = exif.ifds[0].clone();
 
         let gimp_timestamp: Vec<Field> = ifd
             .fields
@@ -194,15 +190,14 @@ mod tests {
         assert!(file.xmp().is_none(), "file only has exif - no xmp.");
 
         // parse exif
-        let mut exif = file
+        let exif = file
             .exif()
-            .clone()
             .expect("exif should be supported + found")
             .expect("exif should be well-formed");
 
         // ensure only one ifd
         assert_eq!(exif.ifds.len(), 1, "should only be one ifd");
-        let ifd: Ifd = exif.ifds.remove(0);
+        let ifd: Ifd = exif.ifds[0].clone();
 
         // grab same gimp timestamp above
         let gimp_timestamp: Vec<Field> = ifd

--- a/raves_metadata/src/providers/gif/mod.rs
+++ b/raves_metadata/src/providers/gif/mod.rs
@@ -416,12 +416,12 @@ impl MetadataProvider for Gif {
         })
     }
 
-    fn exif(&self) -> &Option<Result<Exif, ExifFatalError>> {
-        &None
+    fn exif(&self) -> Option<Result<&Exif, &ExifFatalError>> {
+        None
     }
 
-    fn xmp(&self) -> &Option<Result<Xmp, XmpError>> {
-        &self.xmp
+    fn xmp(&self) -> Option<Result<&Xmp, &XmpError>> {
+        self.xmp.as_ref().map(|r| r.as_ref())
     }
 }
 
@@ -464,7 +464,6 @@ mod tests {
 
         let xmp = gif
             .xmp()
-            .clone()
             .expect("XMP should be present")
             .expect("xmp should have parsed correctly");
 
@@ -540,7 +539,6 @@ mod tests {
 
         let xmp = gif
             .xmp()
-            .clone()
             .expect("XMP should be present")
             .expect("xmp should have parsed correctly");
 

--- a/raves_metadata/src/providers/heic.rs
+++ b/raves_metadata/src/providers/heic.rs
@@ -33,12 +33,12 @@ impl MetadataProvider for Heic {
             .map(|heic_like| Heic { heic_like })
     }
 
-    fn exif(&self) -> &Option<Result<crate::exif::Exif, crate::exif::error::ExifFatalError>> {
-        &self.heic_like.exif
+    fn exif(&self) -> Option<Result<&crate::exif::Exif, &crate::exif::error::ExifFatalError>> {
+        self.heic_like.exif.as_ref().map(|r| r.as_ref())
     }
 
-    fn xmp(&self) -> &Option<Result<crate::xmp::Xmp, crate::xmp::error::XmpError>> {
-        &self.heic_like.xmp
+    fn xmp(&self) -> Option<Result<&crate::xmp::Xmp, &crate::xmp::error::XmpError>> {
+        self.heic_like.xmp.as_ref().map(|r| r.as_ref())
     }
 }
 
@@ -68,7 +68,6 @@ mod tests {
         // grab exif
         let exif = file
             .exif()
-            .clone()
             .expect("file has exif")
             .expect("exif should be well-formed");
 

--- a/raves_metadata/src/providers/jpeg/mod.rs
+++ b/raves_metadata/src/providers/jpeg/mod.rs
@@ -34,12 +34,12 @@ impl MetadataProvider for Jpeg {
         parse::parse(input.as_ref())
     }
 
-    fn exif(&self) -> &Option<Result<Exif, ExifFatalError>> {
-        &self.exif
+    fn exif(&self) -> Option<Result<&Exif, &ExifFatalError>> {
+        self.exif.as_ref().map(|r| r.as_ref())
     }
 
-    fn xmp(&self) -> &Option<Result<Xmp, XmpError>> {
-        &self.xmp
+    fn xmp(&self) -> Option<Result<&Xmp, &XmpError>> {
+        self.xmp.as_ref().map(|r| r.as_ref())
     }
 }
 
@@ -74,8 +74,8 @@ mod tests {
         let file = include_bytes!("../../../assets/providers/jpeg/Calico_Cat_Asleep.jpg");
         let jpeg = Jpeg::new(file).unwrap();
 
-        let exif = jpeg.exif().clone().unwrap().unwrap();
-        let xmp = jpeg.xmp().clone().unwrap().unwrap();
+        let exif = jpeg.exif().unwrap().unwrap();
+        let xmp = jpeg.xmp().unwrap().unwrap();
 
         assert_eq!(
             exif.ifds
@@ -132,7 +132,7 @@ mod tests {
         );
         let jpeg = Jpeg::new(file).unwrap();
 
-        let exif = jpeg.exif().clone().unwrap().unwrap();
+        let exif = jpeg.exif().unwrap().unwrap();
 
         assert_eq!(
             exif.ifds
@@ -171,7 +171,7 @@ mod tests {
         // this file contains extended xmp, but no actual extendedxmp blocks.
         //
         // let's grab the concatenated version we made
-        let xmp = jpeg.xmp().clone().unwrap().unwrap();
+        let xmp = jpeg.xmp().unwrap().unwrap();
 
         // should still contain the original tags.
         //
@@ -202,7 +202,7 @@ mod tests {
         // this file contains extended xmp, but no actual extendedxmp blocks.
         //
         // let's grab the concatenated version we made
-        let xmp = jpeg.xmp().clone().unwrap().unwrap();
+        let xmp = jpeg.xmp().unwrap().unwrap();
 
         assert!(
             xmp.document()

--- a/raves_metadata/src/providers/mov.rs
+++ b/raves_metadata/src/providers/mov.rs
@@ -294,12 +294,12 @@ impl MetadataProvider for Mov {
         parse(input.as_ref())
     }
 
-    fn exif(&self) -> &Option<Result<crate::exif::Exif, crate::exif::error::ExifFatalError>> {
-        &None
+    fn exif(&self) -> Option<Result<&crate::exif::Exif, &crate::exif::error::ExifFatalError>> {
+        None
     }
 
-    fn xmp(&self) -> &Option<Result<Xmp, XmpError>> {
-        &self.xmp
+    fn xmp(&self) -> Option<Result<&Xmp, &XmpError>> {
+        self.xmp.as_ref().map(|r| r.as_ref())
     }
 }
 
@@ -344,7 +344,6 @@ mod tests {
 
         let xmp = mov
             .xmp()
-            .clone()
             .expect("the file contains xmp")
             .expect("the xmp ctor should succeed");
 

--- a/raves_metadata/src/providers/mp4.rs
+++ b/raves_metadata/src/providers/mp4.rs
@@ -34,12 +34,12 @@ impl MetadataProvider for Mp4 {
         parse(input.as_ref())
     }
 
-    fn exif(&self) -> &Option<Result<crate::exif::Exif, crate::exif::error::ExifFatalError>> {
-        &None
+    fn exif(&self) -> Option<Result<&crate::exif::Exif, &crate::exif::error::ExifFatalError>> {
+        None
     }
 
-    fn xmp(&self) -> &Option<Result<Xmp, XmpError>> {
-        &self.xmp
+    fn xmp(&self) -> Option<Result<&Xmp, &XmpError>> {
+        self.xmp.as_ref().map(|r| r.as_ref())
     }
 }
 
@@ -204,7 +204,6 @@ mod tests {
 
         let xmp = mp4
             .xmp()
-            .clone()
             .expect("this file has XMP embedded")
             .expect("should find the XMP data");
 

--- a/raves_metadata/src/providers/png.rs
+++ b/raves_metadata/src/providers/png.rs
@@ -53,12 +53,12 @@ impl MetadataProvider for Png {
         })
     }
 
-    fn exif(&self) -> &Option<Result<Exif, ExifFatalError>> {
-        &self.exif
+    fn exif(&self) -> Option<Result<&Exif, &ExifFatalError>> {
+        self.exif.as_ref().map(|r| r.as_ref())
     }
 
-    fn xmp(&self) -> &Option<Result<Xmp, XmpError>> {
-        &self.xmp
+    fn xmp(&self) -> Option<Result<&Xmp, &XmpError>> {
+        self.xmp.as_ref().map(|r| r.as_ref())
     }
 }
 
@@ -449,7 +449,6 @@ mod tests {
 
         let xmp = png
             .xmp()
-            .clone()
             .expect("this PNG has XMP")
             .expect("get XMP from PNG");
 
@@ -483,7 +482,6 @@ mod tests {
 
         let exif = png
             .exif()
-            .clone()
             .expect("PNG contains Exif")
             .expect("Exif is well-formed");
 

--- a/raves_metadata/src/providers/webp/mod.rs
+++ b/raves_metadata/src/providers/webp/mod.rs
@@ -174,12 +174,12 @@ impl MetadataProvider for Webp {
         Ok(s)
     }
 
-    fn exif(&self) -> &Option<Result<Exif, ExifFatalError>> {
-        &self.exif
+    fn exif(&self) -> Option<Result<&Exif, &ExifFatalError>> {
+        self.exif.as_ref().map(|r| r.as_ref())
     }
 
-    fn xmp(&self) -> &Option<Result<Xmp, XmpError>> {
-        &self.xmp
+    fn xmp(&self) -> Option<Result<&Xmp, &XmpError>> {
+        self.xmp.as_ref().map(|r| r.as_ref())
     }
 }
 
@@ -340,7 +340,6 @@ mod tests {
         // parse the xmp
         let xmp = webp
             .xmp()
-            .clone()
             .expect("XMP is supported _and_ provided in the file")
             .expect("the XMP should construct correctly");
 
@@ -379,7 +378,6 @@ mod tests {
         // parse the xmp
         let xmp = webp
             .xmp()
-            .clone()
             .expect("XMP is supported _and_ provided in the file")
             .expect("the XMP should construct correctly");
 
@@ -421,14 +419,10 @@ mod tests {
         let file = include_bytes!("../../../assets/providers/webp/RIFF.webp");
         let webp: Webp = Webp::new(file).unwrap();
 
-        let exif = webp
-            .exif()
-            .clone()
-            .expect("file has exif")
-            .expect("exif is valid");
+        let exif = webp.exif().expect("file has exif").expect("exif is valid");
 
         assert_eq!(
-            exif,
+            *exif,
             Exif {
                 endianness: Endianness::Big,
                 ifds: vec![Ifd {

--- a/raves_metadata/src/xmp/mod.rs
+++ b/raves_metadata/src/xmp/mod.rs
@@ -93,6 +93,18 @@ impl Xmp {
         Ok(Self { document })
     }
 
+    /// Attempts to parse the given byte slice as an XML string.
+    ///
+    /// Then, tries to parse the XML as an XMP document.
+    pub fn new_from_bytes(bytes: &[u8]) -> Result<Self, XmpError> {
+        let s: &str = core::str::from_utf8(bytes).map_err(|e| {
+            log::error!("Failed to parse given byte slice as UTF-8! err: {e}");
+            XmpError::NotUtf8
+        })?;
+
+        Self::new(s)
+    }
+
     /// Returns the underlying XML document.
     pub fn document(&self) -> &XmpDocument {
         &self.document


### PR DESCRIPTION
These changes remove the use of lazy parsing, including `Arc<RwLock<(...)>>` and `MaybeParsed<R, M>`.

Resolves #59.

## Changes

- Remove types related to locking:
	- Remove `MetadataProviderRaw`
	- Remove `MaybeParsed`
	- Remove `Wrapped`
- Remove dependency on `parking_lot`
	- We're down to 7 dependencies now! :)
	- Clean build times in release mode (on my machine) went from 3.66s to 3.47s.
	- Running tests (with `cargo nextest run --no-fail-fast`, on my machine) went from 0.241s to 0.246s -- a rather small increase that's basically negligible.
		- In other words, eager parsing doesn't make that much of a difference on most files.

## Testing

All tests (and doctests) pass just as before.