### PR TITLE
Add support for writing XMP

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -44,6 +44,15 @@ It only depends on:
 - `env_filter`: provides environment parsing.
   - We don't actually need this, but you can't turn it off, so it's fine...
 
+#### `pretty_assertions`
+
+Provides colorful, diff-like `assert!` and `assert_eq!` macros for tests.
+
+It depends on two other crates:
+
+- `diff`: Tiny library to generate, unsurprisingly, `diff` outputs.
+- `yansi`: Provides terminal styles, cross-platform support, and a high-quality API for consistent output.
+
 ## `raves_metadata_types`
 
 I'm more lenient for dependencies in here. Please make an issue before doing so, nonetheless! :D

--- a/raves_metadata/CHANGELOG.typ
+++ b/raves_metadata/CHANGELOG.typ
@@ -12,6 +12,12 @@ This file is ordered from newest to oldest.
   - Eager parsing seems to be the same amount of "efficient" for most files, as we already gotta parse them anyway!
 - Simplify API (one `MetadataProvider`)
   - In other words, there's no longer a `MetadataProviderRaw`!
+- Add `XmpValue::Uri` support.
+- XMP type changes
+  - Add `Xmp::document_mut` method (for mutating internal values).
+  - Use struct-like parsing style for XMP unions.
+  - Make XMP struct fields require namespaces.
+- Add support for writing XMP (through #link("https://docs.rs/raves_metadata/latest/raves_metadata/xmp/struct.Xmp.html#method.write")[the `Xmp::write` method]).
 
 == v0.0.4
 

--- a/raves_metadata/Cargo.toml
+++ b/raves_metadata/Cargo.toml
@@ -37,3 +37,4 @@ xmltree = { package = "raves_xmltree", version = "0.11.0" }
 
 [dev-dependencies]
 env_logger = { version = "0.11.8", default-features = false }
+pretty_assertions = "1.4.1"

--- a/raves_metadata/Cargo.toml
+++ b/raves_metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raves_metadata"
 description = "A library to parse metadata from media files"
-version = "0.0.4"
+version = "0.1.0"
 readme = "../README.md"
 
 # avoid publishing test assets or the tests themselves
@@ -17,7 +17,7 @@ rust-version.workspace = true
 
 [dependencies]
 log = "0.4.27"
-raves_metadata_types = { version = "0.0.2", path = "../raves_metadata_types" }
+raves_metadata_types = { version = "0.1.0", path = "../raves_metadata_types" }
 winnow = "0.7.11"
 
 

--- a/raves_metadata/assets/metadata_specs/xmp/1.in.xml
+++ b/raves_metadata/assets/metadata_specs/xmp/1.in.xml
@@ -1,0 +1,13 @@
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c145 79.163499, 2018/08/13-16:40:22">
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/" xmlns:tiff="http://ns.adobe.com/tiff/1.0/" xmlns:exif="http://ns.adobe.com/exif/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/" xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#" xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#">
+            <dc:subject>
+                <rdf:Bag>
+                    <rdf:li>farts</rdf:li>
+                    <rdf:li>not farts</rdf:li>
+                    <rdf:li>etc.</rdf:li>
+                </rdf:Bag>
+            </dc:subject>
+        </rdf:Description>
+    </rdf:RDF>
+</x:xmpmeta>

--- a/raves_metadata/assets/metadata_specs/xmp/1.out.xml
+++ b/raves_metadata/assets/metadata_specs/xmp/1.out.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:xmpmeta xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:x="adobe:ns:meta/">
+    <rdf:RDF>
+        <rdf:Description rdf:about="">
+            <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <rdf:Bag>
+                    <rdf:li>etc.</rdf:li>
+                    <rdf:li>farts</rdf:li>
+                    <rdf:li>not farts</rdf:li>
+                </rdf:Bag>
+            </dc:subject>
+        </rdf:Description>
+    </rdf:RDF>
+</x:xmpmeta>

--- a/raves_metadata/assets/metadata_specs/xmp/2.in.xml
+++ b/raves_metadata/assets/metadata_specs/xmp/2.in.xml
@@ -1,0 +1,100 @@
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c145 79.163499, 2018/08/13-16:40:22">
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/" xmlns:tiff="http://ns.adobe.com/tiff/1.0/" xmlns:exif="http://ns.adobe.com/exif/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/" xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#" xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#" xmlns:crs="http://ns.adobe.com/camera-raw-settings/1.0/" xmlns:xmpDM="http://ns.adobe.com/xmp/1.0/DynamicMedia/" xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#">
+            <!--
+
+            simple values
+
+            -->
+
+            <!-- boolean -->
+            <crs:HasCrop>False</crs:HasCrop>
+
+            <!-- date -->
+            <exif:DateTimeDigitized>2026:01:01 01:02:03</exif:DateTimeDigitized>
+
+            <!-- text -->
+            <xmp:Label>Cool</xmp:Label>
+
+            <!-- integer -->
+            <photoshop:Urgency>5</photoshop:Urgency>
+
+            <!-- real -->
+            <xmp:Rating>2</xmp:Rating>
+
+
+            <!--
+
+            struct
+
+            -->
+            <xmpDM:videoFrameSize stDim:unit="pixel" stDim:h="1080" stDim:w="1920" />
+
+            <!--
+
+            union
+
+            -->
+            <xmpDM:videoAlphaPremultipleColor xmlns:xmpDM="http://ns.adobe.com/xmp/1.0/DynamicMedia/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">
+                <rdf:Description>
+                    <xmpTPg:mode>RGB</xmpTPg:mode>
+                    <xmpTPg:swatchName>premultiply white</xmpTPg:swatchName>
+                    <xmpTPg:type>PROCESS</xmpTPg:type>
+                    <xmpTPg:red>255</xmpTPg:red>
+                    <xmpTPg:green>255</xmpTPg:green>
+                    <xmpTPg:blue>255</xmpTPg:blue>
+
+                    <!-- sneak in an unexpected field to test the parser's serialization of it -->
+                    <xmpTPg:unexpectedField>Hello world</xmpTPg:unexpectedField>
+                </rdf:Description>
+            </xmpDM:videoAlphaPremultipleColor>
+
+            <!--
+
+            unordered array
+
+            -->
+            <xmp:Identifier>
+                <rdf:Bag>
+                    <rdf:li>Alice</rdf:li>
+                    <rdf:li>Bob</rdf:li>
+                    <rdf:li>Carol</rdf:li>
+                </rdf:Bag>
+            </xmp:Identifier>
+
+            <!--
+
+            ordered array
+
+            -->
+            <xmpTPg:PlateNames xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">
+                <rdf:Seq>
+                    <rdf:li>FIRST</rdf:li>
+                    <rdf:li>SECOND</rdf:li>
+                    <rdf:li>THIRD</rdf:li>
+                </rdf:Seq>
+            </xmpTPg:PlateNames>
+
+            <!--
+
+            alternatives
+
+            -->
+            <tiff:Copyright>
+                <rdf:Alt>
+                    <rdf:li xml:lang="x-default">FIRST</rdf:li>
+                    <rdf:li xml:lang="en-us">SECOND</rdf:li>
+                    <rdf:li xml:lang="fr">THIRD</rdf:li>
+                </rdf:Alt>
+            </tiff:Copyright>
+            
+            <!--
+
+            URI
+
+            -->
+            <xmpMM:ManageTo rdf:resource="https://github.com/raves-project/"/>
+
+        </rdf:Description>
+    </rdf:RDF>
+</x:xmpmeta>

--- a/raves_metadata/assets/metadata_specs/xmp/2.out.xml
+++ b/raves_metadata/assets/metadata_specs/xmp/2.out.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:xmpmeta xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:x="adobe:ns:meta/">
+    <rdf:RDF>
+        <rdf:Description rdf:about="">
+            <crs:HasCrop xmlns:crs="http://ns.adobe.com/camera-raw-settings/1.0/">False</crs:HasCrop>
+            <exif:DateTimeDigitized xmlns:exif="http://ns.adobe.com/exif/1.0/">2026:01:01 01:02:03</exif:DateTimeDigitized>
+            <photoshop:Urgency xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/">5</photoshop:Urgency>
+            <tiff:Copyright xmlns:tiff="http://ns.adobe.com/tiff/1.0/">
+                <rdf:Alt>
+                    <rdf:li xml:lang="en-us">SECOND</rdf:li>
+                    <rdf:li xml:lang="fr">THIRD</rdf:li>
+                    <rdf:li xml:lang="x-default">FIRST</rdf:li>
+                </rdf:Alt>
+            </tiff:Copyright>
+            <xmp:Identifier xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+                <rdf:Bag>
+                    <rdf:li>Alice</rdf:li>
+                    <rdf:li>Bob</rdf:li>
+                    <rdf:li>Carol</rdf:li>
+                </rdf:Bag>
+            </xmp:Identifier>
+            <xmp:Label xmlns:xmp="http://ns.adobe.com/xap/1.0/">Cool</xmp:Label>
+            <xmp:Rating xmlns:xmp="http://ns.adobe.com/xap/1.0/">2</xmp:Rating>
+            <xmpDM:videoAlphaPremultipleColor xmlns:xmpDM="http://ns.adobe.com/xmp/1.0/DynamicMedia/">
+                <rdf:Description>
+                    <xmpTPg:mode xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">RGB</xmpTPg:mode>
+                    <xmpTPg:blue xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">255</xmpTPg:blue>
+                    <xmpTPg:green xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">255</xmpTPg:green>
+                    <xmpTPg:mode xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">RGB</xmpTPg:mode>
+                    <xmpTPg:red xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">255</xmpTPg:red>
+                    <xmpTPg:swatchName xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">premultiply white</xmpTPg:swatchName>
+                    <xmpTPg:type xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">PROCESS</xmpTPg:type>
+                    <xmpTPg:unexpectedField xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">Hello world</xmpTPg:unexpectedField>
+                </rdf:Description>
+            </xmpDM:videoAlphaPremultipleColor>
+            <xmpDM:videoFrameSize xmlns:xmpDM="http://ns.adobe.com/xmp/1.0/DynamicMedia/">
+                <rdf:Description>
+                    <stDim:h xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#">1080</stDim:h>
+                    <stDim:unit xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#">pixel</stDim:unit>
+                    <stDim:w xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#">1920</stDim:w>
+                </rdf:Description>
+            </xmpDM:videoFrameSize>
+            <xmpMM:ManageTo xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/" rdf:resource="https://github.com/raves-project/" />
+            <xmpTPg:PlateNames xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/g/">
+                <rdf:Seq>
+                    <rdf:li>FIRST</rdf:li>
+                    <rdf:li>SECOND</rdf:li>
+                    <rdf:li>THIRD</rdf:li>
+                </rdf:Seq>
+            </xmpTPg:PlateNames>
+        </rdf:Description>
+    </rdf:RDF>
+</x:xmpmeta>

--- a/raves_metadata/src/providers/avif.rs
+++ b/raves_metadata/src/providers/avif.rs
@@ -46,7 +46,7 @@ mod tests {
             primitives::{Primitive, PrimitiveTy},
             tags::{Ifd0Tag, KnownTag},
         },
-        xmp::{XmpElement, XmpPrimitive, XmpValue},
+        xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue},
     };
 
     use crate::{MetadataProvider as _, exif::Ifd, providers::avif::Avif, util::logger};
@@ -70,10 +70,12 @@ mod tests {
         assert_eq!(
             *xmp_values.first().unwrap(),
             XmpElement {
-                namespace: "http://www.gimp.org/xmp/".into(),
-                prefix: "GIMP".into(),
-                name: "TimeStamp".into(),
-                value: XmpValue::Simple(XmpPrimitive::Text("1613247941462908".into()))
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "GIMP".into(),
+                    "http://www.gimp.org/xmp/".into(),
+                    "TimeStamp".into(),
+                ),
+                value: XmpValue::Simple(XmpPrimitive::Text("1613247941462908".into())),
             },
         );
 
@@ -130,13 +132,15 @@ mod tests {
         assert_eq!(
             *xmp_values
                 .iter()
-                .find(|v| v.name == "AuthorsPosition")
+                .find(|v| v.ident.name == "AuthorsPosition")
                 .unwrap(),
             XmpElement {
-                namespace: "http://ns.adobe.com/photoshop/1.0/".into(),
-                prefix: "photoshop".into(),
-                name: "AuthorsPosition".into(),
-                value: XmpValue::Simple(XmpPrimitive::Text("Computer Scientist".into()))
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "photoshop".into(),
+                    "http://ns.adobe.com/photoshop/1.0/".into(),
+                    "AuthorsPosition".into(),
+                ),
+                value: XmpValue::Simple(XmpPrimitive::Text("Computer Scientist".into())),
             },
         );
 

--- a/raves_metadata/src/providers/gif/mod.rs
+++ b/raves_metadata/src/providers/gif/mod.rs
@@ -427,7 +427,7 @@ impl MetadataProvider for Gif {
 
 #[cfg(test)]
 mod tests {
-    use raves_metadata_types::xmp::XmpElement;
+    use raves_metadata_types::xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue};
 
     use crate::{MetadataProvider, magic_number::AnyProvider, util::logger};
 
@@ -468,56 +468,50 @@ mod tests {
             .expect("xmp should have parsed correctly");
 
         let mut actual = xmp.document().values_ref().to_vec();
-        actual.sort_by(|a, b| a.name.cmp(&b.name));
+        actual.sort_by(|a, b| a.ident.name.cmp(&b.ident.name));
 
         let mut expected = vec![
             XmpElement {
-                namespace: "http://purl.org/dc/elements/1.1/".into(),
-                prefix: "dc".into(),
-                name: "subject".into(),
-                value: raves_metadata_types::xmp::XmpValue::UnorderedArray(vec![XmpElement {
-                    namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                    prefix: "rdf".into(),
-                    name: "li".into(),
-                    value: raves_metadata_types::xmp::XmpValue::Simple(
-                        raves_metadata_types::xmp::XmpPrimitive::Text(
-                            "this better save xmp".into(),
-                        ),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "dc".into(),
+                    "http://purl.org/dc/elements/1.1/".into(),
+                    "subject".into(),
+                ),
+                value: XmpValue::UnorderedArray(vec![XmpElement {
+                    ident: XmpIdent::new_with_one_namespace_pair(
+                        "rdf".into(),
+                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                        "li".into(),
                     ),
+                    value: XmpValue::Simple(XmpPrimitive::Text("this better save xmp".into())),
                 }]),
             },
             XmpElement {
-                namespace: "http://ns.adobe.com/xap/1.0/".into(),
-                prefix: "xmp".into(),
-                name: "CreateDate".into(),
-                value: raves_metadata_types::xmp::XmpValue::Simple(
-                    raves_metadata_types::xmp::XmpPrimitive::Date(
-                        "2026-02-15T02:20:20-06:00".into(),
-                    ),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "xmp".into(),
+                    "http://ns.adobe.com/xap/1.0/".into(),
+                    "CreateDate".into(),
                 ),
+                value: XmpValue::Simple(XmpPrimitive::Date("2026-02-15T02:20:20-06:00".into())),
             },
             XmpElement {
-                namespace: "http://ns.adobe.com/xap/1.0/".into(),
-                prefix: "xmp".into(),
-                name: "MetadataDate".into(),
-                value: raves_metadata_types::xmp::XmpValue::Simple(
-                    raves_metadata_types::xmp::XmpPrimitive::Date(
-                        "2026-02-15T02:20:31-06:00".into(),
-                    ),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "xmp".into(),
+                    "http://ns.adobe.com/xap/1.0/".into(),
+                    "MetadataDate".into(),
                 ),
+                value: XmpValue::Simple(XmpPrimitive::Date("2026-02-15T02:20:31-06:00".into())),
             },
             XmpElement {
-                namespace: "http://ns.adobe.com/xap/1.0/".into(),
-                prefix: "xmp".into(),
-                name: "ModifyDate".into(),
-                value: raves_metadata_types::xmp::XmpValue::Simple(
-                    raves_metadata_types::xmp::XmpPrimitive::Date(
-                        "2026-02-15T02:20:31-06:00".into(),
-                    ),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "xmp".into(),
+                    "http://ns.adobe.com/xap/1.0/".into(),
+                    "ModifyDate".into(),
                 ),
+                value: XmpValue::Simple(XmpPrimitive::Date("2026-02-15T02:20:31-06:00".into())),
             },
         ];
-        expected.sort_by(|a, b| a.name.cmp(&b.name));
+        expected.sort_by(|a, b| a.ident.name.cmp(&b.ident.name));
 
         assert_eq!(actual, expected);
     }
@@ -546,25 +540,27 @@ mod tests {
             xmp.document().values_ref(),
             &[
                 XmpElement {
-                    namespace: "http://purl.org/dc/elements/1.1/".into(),
-                    prefix: "dc".into(),
-                    name: "creator".into(),
-                    value: raves_metadata_types::xmp::XmpValue::OrderedArray(vec![XmpElement {
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        name: "li".into(),
-                        value: raves_metadata_types::xmp::XmpValue::Simple(
-                            raves_metadata_types::xmp::XmpPrimitive::Text("Barrett Ray".into())
-                        )
-                    }])
+                    ident: XmpIdent::new_with_one_namespace_pair(
+                        "dc".into(),
+                        "http://purl.org/dc/elements/1.1/".into(),
+                        "creator".into(),
+                    ),
+                    value: XmpValue::OrderedArray(vec![XmpElement {
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("Barrett Ray".into())),
+                    }]),
                 },
                 XmpElement {
-                    namespace: "http://ns.adobe.com/xap/1.0/".into(),
-                    prefix: "xmp".into(),
-                    name: "Nickname".into(),
-                    value: raves_metadata_types::xmp::XmpValue::Simple(
-                        raves_metadata_types::xmp::XmpPrimitive::Text("cool image".into())
-                    )
+                    ident: XmpIdent::new_with_one_namespace_pair(
+                        "xmp".into(),
+                        "http://ns.adobe.com/xap/1.0/".into(),
+                        "Nickname".into(),
+                    ),
+                    value: XmpValue::Simple(XmpPrimitive::Text("cool image".into())),
                 },
             ]
         );

--- a/raves_metadata/src/providers/jpeg/mod.rs
+++ b/raves_metadata/src/providers/jpeg/mod.rs
@@ -51,7 +51,7 @@ mod tests {
             primitives::{Primitive, PrimitiveTy},
             tags::{Ifd0Tag, KnownTag},
         },
-        xmp::{XmpElement, XmpPrimitive, XmpValue},
+        xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue},
     };
 
     use crate::{MetadataProvider, providers::jpeg::Jpeg, util::logger};
@@ -99,26 +99,32 @@ mod tests {
             xmp.document()
                 .values_ref()
                 .iter()
-                .find(|f| f.prefix == "dc" && f.name == "subject")
+                .find(|f| f.ident.prefix == "dc" && f.ident.name == "subject")
                 .unwrap(),
             &XmpElement {
-                namespace: "http://purl.org/dc/elements/1.1/".into(),
-                prefix: "dc".into(),
-                name: "subject".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "dc".into(),
+                    "http://purl.org/dc/elements/1.1/".into(),
+                    "subject".into(),
+                ),
                 value: XmpValue::UnorderedArray(vec![
                     XmpElement {
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        name: "li".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("cat".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("cat".into())),
                     },
                     XmpElement {
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        name: "li".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("cute".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("cute".into())),
                     },
-                ])
+                ]),
             }
         );
     }
@@ -180,13 +186,15 @@ mod tests {
             xmp.document()
                 .values_ref()
                 .iter()
-                .find(|f| f.prefix == "aux" && f.name == "Lens")
+                .find(|f| f.ident.prefix == "aux" && f.ident.name == "Lens")
                 .unwrap(),
             &XmpElement {
-                namespace: "http://ns.adobe.com/exif/1.0/aux/".into(),
-                prefix: "aux".into(),
-                name: "Lens".into(),
-                value: XmpValue::Simple(XmpPrimitive::Text("Samsung Galaxy S7 Rear Camera".into()))
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "aux".into(),
+                    "http://ns.adobe.com/exif/1.0/aux/".into(),
+                    "Lens".into(),
+                ),
+                value: XmpValue::Simple(XmpPrimitive::Text("Samsung Galaxy S7 Rear Camera".into())),
             }
         );
     }
@@ -208,7 +216,7 @@ mod tests {
             xmp.document()
                 .values_ref()
                 .iter()
-                .any(|v| v.name == "Data" && v.prefix == "GImage")
+                .any(|v| v.ident.name == "Data" && v.ident.prefix == "GImage")
         );
     }
 }

--- a/raves_metadata/src/providers/mov.rs
+++ b/raves_metadata/src/providers/mov.rs
@@ -330,7 +330,7 @@ impl core::error::Error for MovConstructionError {}
 
 #[cfg(test)]
 mod tests {
-    use raves_metadata_types::xmp::{XmpElement, XmpPrimitive, XmpValue};
+    use raves_metadata_types::xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue};
 
     use crate::{MetadataProvider, providers::mov::Mov, util::logger};
 
@@ -351,14 +351,16 @@ mod tests {
             xmp.document()
                 .values_ref()
                 .iter()
-                .find(|v| v.name == "creator")
+                .find(|v| v.ident.name == "creator")
                 .expect("should be a creator field")
                 .value,
             XmpValue::OrderedArray(vec![XmpElement {
-                namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                prefix: "rdf".into(),
-                name: "li".into(),
-                value: XmpValue::Simple(XmpPrimitive::Text("Phil Harvey".into()))
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "rdf".into(),
+                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                    "li".into(),
+                ),
+                value: XmpValue::Simple(XmpPrimitive::Text("Phil Harvey".into())),
             }])
         );
     }

--- a/raves_metadata/src/providers/mp4.rs
+++ b/raves_metadata/src/providers/mp4.rs
@@ -190,7 +190,7 @@ impl core::fmt::Display for Mp4ConstructionError {
 
 #[cfg(test)]
 mod tests {
-    use raves_metadata_types::xmp::{XmpElement, XmpPrimitive, XmpValue};
+    use raves_metadata_types::xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue};
 
     use crate::{MetadataProvider, providers::mp4::Mp4, util::logger};
 
@@ -208,29 +208,37 @@ mod tests {
             .expect("should find the XMP data");
 
         let common_array_element: XmpElement = XmpElement {
-            namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-            prefix: "rdf".into(),
-            name: "li".into(),
+            ident: XmpIdent::new_with_one_namespace_pair(
+                "rdf".into(),
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                "li".into(),
+            ),
             value: XmpValue::Simple(XmpPrimitive::Text("".into())),
         };
 
         let expected = Vec::from([
             XmpElement {
-                namespace: "http://ns.adobe.com/xap/1.0/".into(),
-                prefix: "xmp".into(),
-                name: "MetadataDate".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "xmp".into(),
+                    "http://ns.adobe.com/xap/1.0/".into(),
+                    "MetadataDate".into(),
+                ),
                 value: XmpValue::Simple(XmpPrimitive::Date("2025-08-05T22:08:44-05:00".into())),
             },
             XmpElement {
-                namespace: "http://ns.adobe.com/xap/1.0/".into(),
-                prefix: "xmp".into(),
-                name: "ModifyDate".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "xmp".into(),
+                    "http://ns.adobe.com/xap/1.0/".into(),
+                    "ModifyDate".into(),
+                ),
                 value: XmpValue::Simple(XmpPrimitive::Date("2025-08-05T22:08:44-05:00".into())),
             },
             XmpElement {
-                namespace: "http://purl.org/dc/elements/1.1/".into(),
-                prefix: "dc".into(),
-                name: "subject".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "dc".into(),
+                    "http://purl.org/dc/elements/1.1/".into(),
+                    "subject".into(),
+                ),
                 value: XmpValue::UnorderedArray(
                     [1, 2, 3]
                         .into_iter()
@@ -245,7 +253,7 @@ mod tests {
         ]);
 
         let mut got = xmp.document().values_ref().to_vec();
-        got.sort_by_key(|a| a.name.clone());
+        got.sort_by_key(|a| a.ident.name.clone());
 
         assert_eq!(got, expected);
     }

--- a/raves_metadata/src/providers/png.rs
+++ b/raves_metadata/src/providers/png.rs
@@ -347,7 +347,7 @@ mod tests {
             primitives::{Primitive, Rational},
             tags::{Ifd0Tag, KnownTag},
         },
-        xmp::{XmpElement, XmpValue},
+        xmp::{XmpElement, XmpIdent, XmpValue},
     };
 
     use crate::{MetadataProvider as _, providers::png::Png, util::logger};
@@ -463,9 +463,11 @@ mod tests {
                 .first()
                 .expect("must have an item"),
             &XmpElement {
-                namespace: "https://barretts.club".into(),
-                prefix: "my_ns".into(),
-                name: "MyStruct".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "my_ns".into(),
+                    "https://barretts.club".into(),
+                    "MyStruct".into(),
+                ),
                 value: XmpValue::Struct(Vec::new()),
             },
             "found struct should match the expected (right) side"

--- a/raves_metadata/src/providers/webp/mod.rs
+++ b/raves_metadata/src/providers/webp/mod.rs
@@ -208,7 +208,7 @@ mod tests {
             primitives::{Primitive, PrimitiveTy, Rational},
             tags::{Ifd0Tag, KnownTag},
         },
-        xmp::{XmpElement, XmpPrimitive, XmpValue},
+        xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue},
     };
 
     use crate::{
@@ -346,9 +346,11 @@ mod tests {
         assert_eq!(
             xmp.document().values_ref().first().unwrap(),
             &XmpElement {
-                namespace: "https://barretts.club".into(),
-                prefix: "my_ns".into(),
-                name: "MyStruct".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "my_ns".into(),
+                    "https://barretts.club".into(),
+                    "MyStruct".into(),
+                ),
                 value: XmpValue::Struct(Vec::new()),
             }
         );
@@ -385,29 +387,37 @@ mod tests {
         assert_eq!(
             xmp.document().values_ref().to_vec(),
             vec![XmpElement {
-                namespace: "http://purl.org/dc/elements/1.1/".into(),
-                prefix: "dc".into(),
-                name: "subject".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "dc".into(),
+                    "http://purl.org/dc/elements/1.1/".into(),
+                    "subject".into(),
+                ),
                 value: XmpValue::UnorderedArray(vec![
                     XmpElement {
-                        name: "li".into(),
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("farts".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("farts".into())),
                     },
                     XmpElement {
-                        name: "li".into(),
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("not farts".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("not farts".into())),
                     },
                     XmpElement {
-                        name: "li".into(),
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("etc.".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("etc.".into())),
                     },
-                ])
+                ]),
             }]
         );
     }

--- a/raves_metadata/src/xmp/error.rs
+++ b/raves_metadata/src/xmp/error.rs
@@ -140,7 +140,7 @@ impl From<xmltree::ParseError> for XmpError {
 /// into `None` with `.inspect_err(log::error!(/* ... */)).ok()`, which
 /// provides logs, but doesn't give the user direct error values to sift
 /// through.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum XmpParsingError {
     //
     //
@@ -263,6 +263,28 @@ pub enum XmpParsingError {
         /// Unexpected scheme that was found.
         weird_schema: &'static XmpKind,
     },
+
+    //
+    //
+    //
+    //
+    //
+    //
+    //
+    // uri
+    //
+    /// A URI value had no `rdf:resource` attribute.
+    UriHadNoRdfResource,
+
+    /// A URI value had children, but child elements are disallowed by the
+    /// standard.
+    UriHadChildren {
+        /// How many children the XML element had.
+        number_of_children: u64,
+    },
+
+    /// A URI value had inner text, but that's not allowed by the standard.
+    UriHadInnerText,
 
     //
     //
@@ -395,6 +417,29 @@ impl core::fmt::Display for XmpParsingError {
                 wasn't for an array. \n\
 - schema: {weird_schema:?}",
             ),
+
+            //
+            //
+            //
+            //
+            //
+            //
+            //
+            // URIs
+            //
+            XmpParsingError::UriHadNoRdfResource => {
+                f.write_str("A URI value had no `rdf:resource` attribute.")
+            }
+            XmpParsingError::UriHadChildren { number_of_children } => write!(
+                f,
+                "A URI value had {number_of_children} children, \
+                but child elements are disallowed by the standard."
+            ),
+            XmpParsingError::UriHadInnerText => f.write_str(
+                "A URI value had inner text, \
+                    but that's not allowed by the standard.",
+            ),
+
             //
             //
             //

--- a/raves_metadata/src/xmp/error.rs
+++ b/raves_metadata/src/xmp/error.rs
@@ -17,6 +17,9 @@ pub type XmpValueResult = Result<XmpValue, XmpParsingError>;
 /// This may or may not contain an error.
 pub type XmpElementResult = Result<XmpElement, XmpParsingError>;
 
+/// A result obtained when serializing an XMP document.
+pub type XmpWriteResult<T> = Result<T, XmpWriteError>;
+
 use std::sync::Arc;
 
 /// This is an error that happened while we were parsing XMP.
@@ -131,6 +134,40 @@ impl core::error::Error for XmpError {
 impl From<xmltree::ParseError> for XmpError {
     fn from(value: xmltree::ParseError) -> Self {
         XmpError::XmlParseError(value.into())
+    }
+}
+
+/// An error that occurred when writing XMP as XML.
+#[derive(Clone, Debug, PartialEq, PartialOrd, Hash)]
+#[non_exhaustive]
+pub enum XmpWriteError {
+    /// The provided writer (`W`) returned an I/O error.
+    Io(String),
+
+    /// The underlying XML writer failed to write the document.
+    ///
+    /// This could be due to a number of reasons, though it's likely due to the
+    /// destination referred to by `Write` being unavailable.
+    ///
+    /// Please see the contained error's `Display` output for more info.
+    /// (that's the string)
+    XmlWrite(String),
+}
+
+impl core::fmt::Display for XmpWriteError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "Encountered I/O error while writing XML. err: {err}"),
+            Self::XmlWrite(err) => {
+                write!(f, "The XML writer failed to write. err: {err}")
+            }
+        }
+    }
+}
+
+impl core::error::Error for XmpWriteError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        None
     }
 }
 

--- a/raves_metadata/src/xmp/error.rs
+++ b/raves_metadata/src/xmp/error.rs
@@ -3,7 +3,7 @@
 use std::num::{ParseFloatError, ParseIntError};
 
 use raves_metadata_types::xmp::{
-    XmpElement, XmpValue,
+    XmpElement, XmpValue, XmpValueAlternative,
     parse_types::{XmpKind, XmpKindStructField},
 };
 
@@ -249,7 +249,7 @@ pub enum XmpParsingError {
         /// The list of alternatives.
         ///
         /// One of these should have a default value, but none did!
-        alternatives_array: Vec<(String, XmpElement)>,
+        alternatives_array: Vec<(String, XmpValueAlternative)>,
     },
 
     /// The list (un/ordered array) parser was given a schema for, e.g., a

--- a/raves_metadata/src/xmp/mod.rs
+++ b/raves_metadata/src/xmp/mod.rs
@@ -17,7 +17,9 @@
 
 extern crate alloc;
 
-use raves_metadata_types::xmp::{XmpElement, XmpPrimitive, XmpValue, parse_types::XmpKind as Kind};
+use raves_metadata_types::xmp::{
+    XmpElement, XmpIdent, XmpPrimitive, XmpValue, parse_types::XmpKind as Kind,
+};
 use xmltree::{AttributeName, Element};
 
 use crate::xmp::{
@@ -146,7 +148,7 @@ impl Xmp {
     ///         .document()
     ///         .values_ref()
     ///         .iter()
-    ///         .map(|v| v.name.clone())
+    ///         .map(|v| v.ident.name.clone())
     ///         .collect::<Vec<_>>(),
     ///     vec!["subject", "MyStruct"],
     /// );
@@ -363,10 +365,7 @@ fn parse_attribute((key, value): (AttributeName, String)) -> Option<XmpElement> 
         };
 
         XmpElement {
-            namespace: ns,
-            prefix,
-            name: key.local_name,
-
+            ident: XmpIdent::new_with_one_namespace_pair(prefix, ns, key.local_name),
             value,
         }
     })
@@ -416,7 +415,7 @@ fn parse_element(element: &Element) -> Option<XmpElement> {
 
 #[cfg(test)]
 mod tests {
-    use raves_metadata_types::xmp::{XmpElement, XmpPrimitive, XmpValue};
+    use raves_metadata_types::xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue};
 
     use crate::xmp::{Xmp, XmpDocument};
 
@@ -483,10 +482,12 @@ mod tests {
         assert_eq!(
             xmp.document().0,
             vec![XmpElement {
-                namespace: "https://github.com/onkoe".into(),
-                prefix: "my_ns".into(),
-                name: "MyStruct".into(),
-                value: XmpValue::Struct(vec![])
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "my_ns".into(),
+                    "https://github.com/onkoe".into(),
+                    "MyStruct".into(),
+                ),
+                value: XmpValue::Struct(vec![]),
             }]
         );
     }
@@ -524,29 +525,37 @@ mod tests {
         assert_eq!(
             xmp.document().0,
             vec![XmpElement {
-                namespace: "http://purl.org/dc/elements/1.1/".into(),
-                prefix: "dc".into(),
-                name: "subject".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "dc".into(),
+                    "http://purl.org/dc/elements/1.1/".into(),
+                    "subject".into(),
+                ),
                 value: XmpValue::UnorderedArray(vec![
                     XmpElement {
-                        name: "li".into(),
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("farts".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("farts".into())),
                     },
                     XmpElement {
-                        name: "li".into(),
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("not farts".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("not farts".into())),
                     },
                     XmpElement {
-                        name: "li".into(),
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("etc.".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("etc.".into())),
                     },
-                ])
+                ]),
             }]
         );
     }

--- a/raves_metadata/src/xmp/mod.rs
+++ b/raves_metadata/src/xmp/mod.rs
@@ -30,6 +30,7 @@ use crate::xmp::{
 pub mod error;
 mod heuristics;
 mod value;
+mod write;
 
 /// Re-exports of the XMP types from `raves_metadata_types`.
 ///

--- a/raves_metadata/src/xmp/mod.rs
+++ b/raves_metadata/src/xmp/mod.rs
@@ -113,6 +113,11 @@ impl Xmp {
         &self.document
     }
 
+    /// Returns the underlying XML document in a mutable way.
+    pub fn document_mut(&mut self) -> &mut XmpDocument {
+        &mut self.document
+    }
+
     /// Combines this XMP document with another one.
     ///
     /// Required to implement things like Extended XMP in JPEG.

--- a/raves_metadata/src/xmp/value/arrays.rs
+++ b/raves_metadata/src/xmp/value/arrays.rs
@@ -1,13 +1,10 @@
-use raves_metadata_types::xmp::{
-    XmpValue,
-    parse_types::{XmpKind as Kind, XmpPrimitiveKind as Prim},
-};
-use xmltree::{Element, XMLNode};
+use raves_metadata_types::xmp::{XmpValue, XmpValueAlternative, parse_types::XmpKind as Kind};
+use xmltree::{AttributeName, Element, XMLNode};
 
 use crate::xmp::{
     RDF_NAMESPACE,
     error::{XmpElementResult, XmpParsingError},
-    value::{XmpElementExt, prims::parse_primitive},
+    value::XmpElementExt,
 };
 
 /// Parses an element's value as a list of alternatives.
@@ -72,14 +69,14 @@ pub fn value_alternatives(
             ns.as_str() == RDF_NAMESPACE && maybe_li.name.as_str() == "li"
         });
 
-    // parse each `rdf:li` into a (tag, `XmpValue`) pair
-    let parsed_lis: Vec<_> = lis
+    // parse each `rdf:li` into a (tag, `XmpValueAlternative`) pair
+    let parsed_lis: Vec<((&AttributeName, &String), String)> = lis
         .flat_map(|li| {
             // we need to know which case we're workin with.
             //
             // each li should have a case tag
             let maybe_tag_primitive = li.attributes.iter().find(|(keys, _)| {
-                // check prefix (TODO: does `xml` have a namespace URI?)
+                // only include attrs with the `xml` prefix
                 if keys
                     .prefix
                     .as_ref()
@@ -95,13 +92,13 @@ pub fn value_alternatives(
                     return false;
                 }
 
-                // check element
+                // only include attributes with the name `lang`
                 if keys.local_name.as_str() != "lang" {
                     log::trace!(
-                        "`rdf:li` attr isn't a case tag - missing `xml` namespace prefix. \
-                        got: `{prefix:?}`, \
-                        expected: `Some(\"xml\")`",
-                        prefix = keys.prefix
+                        "`rdf:li` attr isn't a case tag - missing `lang` local name. \
+                        got: `{}`, \
+                        expected: `\"lang\"`",
+                        keys.local_name
                     );
                     return false;
                 }
@@ -109,47 +106,24 @@ pub fn value_alternatives(
                 true
             });
 
+            // if we found the `rdf:lang="<SOMETHING>" attribute, we'll keep
+            // this alternative :)
             if let Some(tag_primitive) = maybe_tag_primitive {
-                return Some((
-                    tag_primitive,
-                    li.to_xmp_element(
-                        parse_primitive(li.get_text()?.to_string(), &Prim::Text)
-                            .inspect_err(|e| log::error!("Couldn't parse primitive! err: {e}"))
-                            .ok()?,
-                    )
-                    .inspect_err(|e| log::error!("Failed to create `XmpElement`. err: {e}"))
-                    .ok()?,
-                ));
+                return Some((tag_primitive, li.get_text()?.to_string()));
             }
 
+            // otherwise, we won't.
             None
         })
         .collect();
 
-    // find the default one based on the marker
-    let Some(((_chosen_tag_idents, chosen_tag_value), chosen_value)) = parsed_lis
-        .iter()
-        .find(|((_tag_idents, tag_value), _)| tag_value.as_str() == "x-default")
-        .cloned()
-    else {
-        log::error!("Can't create list of alternatives - no default was found.");
-        log::error!("The options found were: {parsed_lis:#?}");
-        return Err(XmpParsingError::ArrayAltNoDefault {
-            element_name: element.name.clone(),
-            alternatives_array: Vec::from_iter(parsed_lis.iter().map(
-                |((_tag_idents, tag_value), parsed_li_elem)| {
-                    ((*tag_value).clone(), parsed_li_elem.clone())
-                },
-            )),
-        });
-    };
-
     // wrap it all up
     let value = XmpValue::Alternatives {
-        chosen: (chosen_tag_value.into(), Box::new(chosen_value)),
         list: parsed_lis
             .into_iter()
-            .map(|((_tag_idents, tag_value), value)| (tag_value.clone(), value))
+            .map(|((_tag_idents, lang), text)| {
+                (lang.clone(), XmpValueAlternative { text: text.clone() })
+            })
             .collect(),
     };
 
@@ -279,9 +253,11 @@ fn value_array(
 
 #[cfg(test)]
 mod tests {
-    use raves_metadata_types::{
-        xmp::parse_table::XMP_PARSING_MAP,
-        xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue, XmpValueStructField},
+    use std::collections::BTreeMap;
+
+    use raves_metadata_types::xmp::{
+        XmpElement, XmpIdent, XmpPrimitive, XmpValue, XmpValueAlternative, XmpValueStructField,
+        parse_table::XMP_PARSING_MAP,
     };
     use xmltree::Element;
 
@@ -323,87 +299,38 @@ mod tests {
                     "title".into(),
                 ),
                 value: XmpValue::Alternatives {
-                    chosen: (
-                        "x-default".into(),
-                        XmpElement {
-                            ident: XmpIdent::new_with_one_namespace_pair(
-                                "rdf".into(),
-                                "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                "li".into(),
-                            ),
-                            value: XmpValue::Simple(XmpPrimitive::Text(
-                                "The Default. Uh... hi!".into(),
-                            )),
-                        }
-                        .into(),
-                    ),
-                    list: vec![
+                    list: BTreeMap::from([
                         (
                             "x-default".into(),
-                            XmpElement {
-                                ident: XmpIdent::new_with_one_namespace_pair(
-                                    "rdf".into(),
-                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                    "li".into(),
-                                ),
-                                value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "The Default. Uh... hi!".into(),
-                                )),
-                            },
+                            XmpValueAlternative {
+                                text: "The Default. Uh... hi!".into()
+                            }
                         ),
                         (
                             "en-US".into(),
-                            XmpElement {
-                                ident: XmpIdent::new_with_one_namespace_pair(
-                                    "rdf".into(),
-                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                    "li".into(),
-                                ),
-                                value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "English (United States). Howdy!".into(),
-                                )),
-                            },
+                            XmpValueAlternative {
+                                text: "English (United States). Howdy!".into()
+                            }
                         ),
                         (
                             "de".into(),
-                            XmpElement {
-                                ident: XmpIdent::new_with_one_namespace_pair(
-                                    "rdf".into(),
-                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                    "li".into(),
-                                ),
-                                value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "German. Guten Tag!".into(),
-                                )),
-                            },
+                            XmpValueAlternative {
+                                text: "German. Guten Tag!".into()
+                            }
                         ),
                         (
                             "fr".into(),
-                            XmpElement {
-                                ident: XmpIdent::new_with_one_namespace_pair(
-                                    "rdf".into(),
-                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                    "li".into(),
-                                ),
-                                value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "French. Bonjour !".into(),
-                                )),
-                            },
+                            XmpValueAlternative {
+                                text: "French. Bonjour !".into()
+                            }
                         ),
                         (
                             "ja".into(),
-                            XmpElement {
-                                ident: XmpIdent::new_with_one_namespace_pair(
-                                    "rdf".into(),
-                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                    "li".into(),
-                                ),
-                                value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "Japanese. こんにちは！".into(),
-                                )),
-                            },
+                            XmpValueAlternative {
+                                text: "Japanese. こんにちは！".into()
+                            }
                         ),
-                    ],
+                    ]),
                 },
             },
             "the parsed XMP element should match the expected value."

--- a/raves_metadata/src/xmp/value/arrays.rs
+++ b/raves_metadata/src/xmp/value/arrays.rs
@@ -281,14 +281,13 @@ fn value_array(
 mod tests {
     use raves_metadata_types::{
         xmp::parse_table::XMP_PARSING_MAP,
-        xmp::{XmpElement, XmpPrimitive, XmpValue, XmpValueStructField},
+        xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue, XmpValueStructField},
     };
     use xmltree::Element;
 
     use crate::xmp::value::arrays::{
         value_alternatives, value_ordered_array, value_unordered_array,
     };
-
     /// Ensures we can parse a short array of alternatives.
     #[test]
     fn should_parse_alternatives() {
@@ -318,80 +317,94 @@ mod tests {
         assert_eq!(
             xmp_element,
             XmpElement {
-                namespace: "http://purl.org/dc/elements/1.1/".into(),
-                prefix: "dc".into(),
-                name: "title".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "dc".into(),
+                    "http://purl.org/dc/elements/1.1/".into(),
+                    "title".into(),
+                ),
                 value: XmpValue::Alternatives {
                     chosen: (
                         "x-default".into(),
                         XmpElement {
-                            namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                            prefix: "rdf".into(),
-                            name: "li".into(),
+                            ident: XmpIdent::new_with_one_namespace_pair(
+                                "rdf".into(),
+                                "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                                "li".into(),
+                            ),
                             value: XmpValue::Simple(XmpPrimitive::Text(
-                                "The Default. Uh... hi!".into()
-                            ))
+                                "The Default. Uh... hi!".into(),
+                            )),
                         }
-                        .into()
+                        .into(),
                     ),
                     list: vec![
                         (
                             "x-default".into(),
                             XmpElement {
-                                namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                prefix: "rdf".into(),
-                                name: "li".into(),
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "rdf".into(),
+                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                                    "li".into(),
+                                ),
                                 value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "The Default. Uh... hi!".into()
-                                ))
-                            }
+                                    "The Default. Uh... hi!".into(),
+                                )),
+                            },
                         ),
                         (
                             "en-US".into(),
                             XmpElement {
-                                namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                prefix: "rdf".into(),
-                                name: "li".into(),
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "rdf".into(),
+                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                                    "li".into(),
+                                ),
                                 value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "English (United States). Howdy!".into()
-                                ))
-                            }
+                                    "English (United States). Howdy!".into(),
+                                )),
+                            },
                         ),
                         (
                             "de".into(),
                             XmpElement {
-                                namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                prefix: "rdf".into(),
-                                name: "li".into(),
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "rdf".into(),
+                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                                    "li".into(),
+                                ),
                                 value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "German. Guten Tag!".into()
-                                ))
-                            }
+                                    "German. Guten Tag!".into(),
+                                )),
+                            },
                         ),
                         (
                             "fr".into(),
                             XmpElement {
-                                namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                prefix: "rdf".into(),
-                                name: "li".into(),
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "rdf".into(),
+                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                                    "li".into(),
+                                ),
                                 value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "French. Bonjour !".into()
-                                ))
-                            }
+                                    "French. Bonjour !".into(),
+                                )),
+                            },
                         ),
                         (
                             "ja".into(),
                             XmpElement {
-                                namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                                prefix: "rdf".into(),
-                                name: "li".into(),
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "rdf".into(),
+                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                                    "li".into(),
+                                ),
                                 value: XmpValue::Simple(XmpPrimitive::Text(
-                                    "Japanese. こんにちは！".into()
-                                ))
-                            }
+                                    "Japanese. こんにちは！".into(),
+                                )),
+                            },
                         ),
-                    ]
-                }
+                    ],
+                },
             },
             "the parsed XMP element should match the expected value."
         );
@@ -438,74 +451,88 @@ mod tests {
         assert_eq!(
             xmp,
             XmpElement {
-                namespace: "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into(),
-                prefix: "Iptc4xmpExt".into(),
-                name: "rbVertices".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "Iptc4xmpExt".into(),
+                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into(),
+                    "rbVertices".into(),
+                ),
                 value: XmpValue::OrderedArray(vec![
                     XmpElement {
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        name: "li".into(),
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
                         value: XmpValue::Struct(vec![
                             XmpValueStructField::Value {
-                                ident: "rbX".into(),
-                                namespace: Some(
-                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into()
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "Iptc4xmpExt".into(),
+                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into(),
+                                    "rbX".into(),
                                 ),
-                                value: XmpValue::Simple(XmpPrimitive::Text("0.05".into()))
+                                value: XmpValue::Simple(XmpPrimitive::Text("0.05".into())),
                             },
                             XmpValueStructField::Value {
-                                ident: "rbY".into(),
-                                namespace: Some(
-                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into()
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "Iptc4xmpExt".into(),
+                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into(),
+                                    "rbY".into(),
                                 ),
-                                value: XmpValue::Simple(XmpPrimitive::Text("0.713".into()))
+                                value: XmpValue::Simple(XmpPrimitive::Text("0.713".into())),
                             },
                         ]),
                     },
                     XmpElement {
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        name: "li".into(),
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
                         value: XmpValue::Struct(vec![
                             XmpValueStructField::Value {
-                                ident: "rbX".into(),
-                                namespace: Some(
-                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into()
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "Iptc4xmpExt".into(),
+                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into(),
+                                    "rbX".into(),
                                 ),
-                                value: XmpValue::Simple(XmpPrimitive::Text("0.148".into()))
+                                value: XmpValue::Simple(XmpPrimitive::Text("0.148".into())),
                             },
                             XmpValueStructField::Value {
-                                ident: "rbY".into(),
-                                namespace: Some(
-                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into()
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "Iptc4xmpExt".into(),
+                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into(),
+                                    "rbY".into(),
                                 ),
-                                value: XmpValue::Simple(XmpPrimitive::Text("0.041".into()))
+                                value: XmpValue::Simple(XmpPrimitive::Text("0.041".into())),
                             },
                         ]),
                     },
                     XmpElement {
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        name: "li".into(),
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
                         value: XmpValue::Struct(vec![
                             XmpValueStructField::Value {
-                                ident: "rbX".into(),
-                                namespace: Some(
-                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into()
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "Iptc4xmpExt".into(),
+                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into(),
+                                    "rbX".into(),
                                 ),
-                                value: XmpValue::Simple(XmpPrimitive::Text("0.375".into()))
+                                value: XmpValue::Simple(XmpPrimitive::Text("0.375".into())),
                             },
                             XmpValueStructField::Value {
-                                ident: "rbY".into(),
-                                namespace: Some(
-                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into()
+                                ident: XmpIdent::new_with_one_namespace_pair(
+                                    "Iptc4xmpExt".into(),
+                                    "http://iptc.org/std/Iptc4xmpExt/2008-02-29/".into(),
+                                    "rbY".into(),
                                 ),
-                                value: XmpValue::Simple(XmpPrimitive::Text("0.863".into()))
+                                value: XmpValue::Simple(XmpPrimitive::Text("0.863".into())),
                             },
                         ]),
-                    }
-                ])
+                    },
+                ]),
             }
         );
     }
@@ -541,23 +568,29 @@ mod tests {
         assert_eq!(
             xmp,
             XmpElement {
-                namespace: "http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/".into(),
-                prefix: "Iptc4xmpCore".into(),
-                name: "Scene".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "Iptc4xmpCore".into(),
+                    "http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/".into(),
+                    "Scene".into(),
+                ),
                 value: XmpValue::UnorderedArray(vec![
                     XmpElement {
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        name: "li".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("011221".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("011221".into())),
                     },
                     XmpElement {
-                        namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                        prefix: "rdf".into(),
-                        name: "li".into(),
-                        value: XmpValue::Simple(XmpPrimitive::Text("012221".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "rdf".into(),
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                            "li".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("012221".into())),
                     },
-                ])
+                ]),
             }
         );
     }

--- a/raves_metadata/src/xmp/value/mod.rs
+++ b/raves_metadata/src/xmp/value/mod.rs
@@ -19,6 +19,7 @@ pub mod arrays;
 pub mod prims;
 pub mod structs;
 pub mod unions;
+pub mod uris;
 
 pub trait XmpElementExt {
     /// Uses an element's schema to parse it.
@@ -60,6 +61,11 @@ impl XmpElementExt for Element {
                     .to_string(),
                 prim,
             )?),
+
+            // we're a URI!
+            //
+            // simply call its handler function
+            Kind::Uri => uris::value_uri(self, Some(schema)),
 
             // we're a struct-like kind.
             //
@@ -130,7 +136,23 @@ impl XmpElementExt for Element {
             };
         }
 
-        // 4. if we have text at this point, we can use that as a `Text`
+        // 4. if we have no children, no text, and at least one attribute, we
+        // should check if we're a URI.
+        //
+        // URIs store their data in the `rdf:
+        if self.children.is_empty() && self.get_text().is_none() && !self.attributes.is_empty() {
+            log::trace!("Checking if generic value is a URI...");
+
+            // parse it as a URI
+            if let Ok(xmp_element) = uris::value_uri(self, None) {
+                log::trace!("Given value was a URI!");
+                return Ok(xmp_element);
+            } else {
+                log::trace!("Not a URI.")
+            }
+        }
+
+        // 5. if we have text at this point, we can use that as a `Text`
         // primitive.
         //
         // but, other than that, we're out of ideas...

--- a/raves_metadata/src/xmp/value/mod.rs
+++ b/raves_metadata/src/xmp/value/mod.rs
@@ -1,5 +1,5 @@
 use raves_metadata_types::xmp::{
-    XmpElement, XmpValue,
+    XmpElement, XmpIdent, XmpValue,
     parse_types::{XmpKind as Kind, XmpPrimitiveKind as Prim},
 };
 use xmltree::Element;
@@ -199,9 +199,11 @@ impl XmpElementExt for Element {
         };
 
         Ok(XmpElement {
-            namespace: namespace.into(),
-            prefix: prefix.into(),
-            name: (&self.name).into(),
+            ident: XmpIdent::new_with_one_namespace_pair(
+                prefix.into(),
+                namespace.into(),
+                self.name.clone(),
+            ),
             value,
         })
     }

--- a/raves_metadata/src/xmp/value/structs.rs
+++ b/raves_metadata/src/xmp/value/structs.rs
@@ -27,13 +27,7 @@ pub fn value_struct(
 
         log::trace!("A schema was given! Checking field info...");
         schema_fields.iter().find(|field| {
-            field.ident.name() == field_name
-                && if let Some(string_ns) = field_ns {
-                    log::trace!("Field namespace found! Will return based on namespace eq...");
-                    field.ident.ns() == Some(string_ns)
-                } else {
-                    field.ident.ns().is_none()
-                }
+            field.ident.field_name == field_name && *field_ns == Some(field.ident.namespace)
         })
     };
 
@@ -87,11 +81,7 @@ pub fn value_struct(
                 Constructing accordingly..."
             );
             return Some(XmpValueStructField::Value {
-                ident: XmpIdent::new_with_one_namespace_pair(
-                    prefix,
-                    namespace,
-                    name.to_string(),
-                ),
+                ident: XmpIdent::new_with_one_namespace_pair(prefix, namespace, name.to_string()),
                 value: parse_primitive(value.into(), prim)
                     .inspect_err(|e| {
                         log::error!(
@@ -221,6 +211,7 @@ pub fn value_struct_field(
 
 #[cfg(test)]
 mod tests {
+
     use crate::xmp::Xmp;
 
     /// The parser should be able to handle several different layouts of

--- a/raves_metadata/src/xmp/value/structs.rs
+++ b/raves_metadata/src/xmp/value/structs.rs
@@ -1,5 +1,5 @@
 use raves_metadata_types::xmp::{
-    XmpElement, XmpPrimitive, XmpValue, XmpValueStructField,
+    XmpElement, XmpIdent, XmpPrimitive, XmpValue, XmpValueStructField,
     parse_types::{XmpKind as Kind, XmpKindStructField as Field},
 };
 use xmltree::Element;
@@ -57,6 +57,21 @@ pub fn value_struct(
         // do something else
         log::trace!("Getting field info on struct field: `{name}`");
         if let Some(field_info) = get_field_info(ns, name) {
+            let Some(prefix) = keys.prefix.clone() else {
+                log::warn!(
+                    "Known struct attribute had no prefix. Skipping field `{name}` on `{}`.",
+                    element.name
+                );
+                return None;
+            };
+            let Some(namespace) = ns.map(str::to_owned) else {
+                log::warn!(
+                    "Known struct attribute had no namespace. Skipping field `{name}` on `{}`.",
+                    element.name
+                );
+                return None;
+            };
+
             // check that it's a primitive
             let Kind::Simple(prim) = field_info.ty else {
                 log::error!(
@@ -72,8 +87,11 @@ pub fn value_struct(
                 Constructing accordingly..."
             );
             return Some(XmpValueStructField::Value {
-                ident: field_info.ident.name().into(),
-                namespace: field_info.ident.ns().map(|ns| ns.into()),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    prefix,
+                    namespace,
+                    name.to_string(),
+                ),
                 value: parse_primitive(value.into(), prim)
                     .inspect_err(|e| {
                         log::error!(
@@ -91,9 +109,23 @@ pub fn value_struct(
             "Struct field `{name}` was not in the schema! \
             Constructing text value..."
         );
+        let Some(prefix) = keys.prefix.clone() else {
+            log::warn!(
+                "Unknown struct attribute had no prefix. Skipping field `{name}` on `{}`.",
+                element.name
+            );
+            return None;
+        };
+        let Some(namespace) = ns.map(str::to_owned) else {
+            log::warn!(
+                "Unknown struct attribute had no namespace. Skipping field `{name}` on `{}`.",
+                element.name
+            );
+            return None;
+        };
+
         Some(XmpValueStructField::Value {
-            ident: name.into(),
-            namespace: (*ns).map(|n| n.into()),
+            ident: XmpIdent::new_with_one_namespace_pair(prefix, namespace, name.to_string()),
             value: XmpValue::Simple(XmpPrimitive::Text(value.into())),
         })
     });
@@ -161,42 +193,29 @@ pub fn value_struct_field(
     // if we know the field we're workin with, we can apply its schema.
     //
     // otherwise, we'll have to guess carefully...
-    let (ident, namespace, element) = match maybe_field_kind {
+    let element = match maybe_field_kind {
         // get em from the schema
-        Some(field_kind) => (
-            field_kind.ident.name().into(),
-            field_kind.ident.ns().map(|s| s.into()),
-            element
-                .value_with_schema(field_kind.ty)
-                .inspect_err(|e| log::error!("Field with known schema failed to parse! err: {e}"))
-                .ok()?,
-        ),
+        Some(field_kind) => element
+            .value_with_schema(field_kind.ty)
+            .inspect_err(|e| log::error!("Field with known schema failed to parse! err: {e}"))
+            .ok()?,
 
         // get em from the field
-        None => (
-            element.name.clone(),
-            element.namespace.clone(),
-            match element.value_generic() {
-                Ok(s) => s,
-                Err(e) => {
-                    log::trace!("Parsing value generically failed! err: {e}");
-                    return None;
-                }
-            },
-        ),
+        None => match element.value_generic() {
+            Ok(s) => s,
+            Err(e) => {
+                log::trace!("Parsing value generically failed! err: {e}");
+                return None;
+            }
+        },
     };
 
     Some(match element.value {
         XmpValue::Simple(_) => XmpValueStructField::Value {
-            ident,
-            namespace,
+            ident: element.ident,
             value: element.value,
         },
-        _ => XmpValueStructField::Element {
-            ident,
-            namespace,
-            element,
-        },
+        _ => XmpValueStructField::Element(element),
     })
 }
 

--- a/raves_metadata/src/xmp/value/unions.rs
+++ b/raves_metadata/src/xmp/value/unions.rs
@@ -5,7 +5,9 @@ use raves_metadata_types::xmp::{
 use xmltree::Element;
 
 use crate::xmp::{
+    RDF_NAMESPACE,
     error::{XmpElementResult, XmpParsingError},
+    heuristics::XmpElementHeuristicsExt as _,
     value::{XmpElementExt, structs::value_struct_field},
 };
 
@@ -45,6 +47,31 @@ pub fn value_union(
         });
     };
 
+    // see if we have an `rdf:Description` field container or not
+    let field_parent: &Element = if element.attributes.iter().any(|attr| {
+        attr.0
+            .namespace
+            .as_ref()
+            .is_some_and(|ns: &String| *ns == RDF_NAMESPACE)
+            && attr.0.local_name == "parseType"
+            && attr.1 == "Resource"
+    }) {
+        element
+    } else if let Some(s) = element
+        .get_child("Description")
+        .filter(|desc_elem| desc_elem.is_rdf_description())
+    {
+        s
+    } else {
+        log::error!(
+            "Supposed union didn't seem to have any fields. \
+            Returning a discriminant error."
+        );
+        return Err(XmpParsingError::UnionNoDiscriminant {
+            element_name: element.name.clone(),
+        });
+    };
+
     // we're about to find all the fields.
     //
     // first, for perf, let's grab:
@@ -72,8 +99,9 @@ pub fn value_union(
 
     // find all fields
     let mut expected_fields: Vec<_> = Vec::with_capacity(always.len());
-    let mut unexpected_fields: Vec<_> = Vec::with_capacity(element.children.len() - always.len());
-    for c in element.children.iter().flat_map(|c| c.as_element()) {
+    let mut unexpected_fields: Vec<_> =
+        Vec::with_capacity(field_parent.children.len().saturating_sub(always.len()));
+    for c in field_parent.children.iter().flat_map(|c| c.as_element()) {
         // grab namespace + name
         let (c_ns, c_name) = (&c.namespace, &c.name);
 

--- a/raves_metadata/src/xmp/value/unions.rs
+++ b/raves_metadata/src/xmp/value/unions.rs
@@ -80,27 +80,10 @@ pub fn value_union(
         // check if we know this field
         let mut known_field = false;
         for (field, (known_ns, known_name)) in &known_pairs {
-            // if the namespaces don't match, it's not this pair!
-            //
-            // sorry for this being so sloppy - need to compare both the
-            // Some + None cases, and we don't own the &'static str...
-            let ns_mismatch = match c_ns {
-                Some(c_ns) => Some(c_ns.as_str()) != known_ns.map(|k: &str| k),
-                None => known_ns.is_some(),
-            };
-            if ns_mismatch {
+            if !(c_ns.as_deref() == Some(known_ns) && c_name == known_name) {
                 log::trace!(
-                    "Namespaces don't match - not a known field. found: `{c_ns:?}`, want: `{known_ns:?}`."
-                );
-                continue;
-            }
-
-            // if the names don't match, we can skip the pair
-            if c_name != *known_name {
-                log::trace!(
-                    "Names don't match - not a known field. \
-                    found: {c_name} \
-                    want: {known_name}"
+                    "Field does not match a known (namespace, name) pair. \
+                    found: `({c_ns:?}, {c_name})`, want: `({known_ns:?}, {known_name})`."
                 );
                 continue;
             }
@@ -134,10 +117,8 @@ pub fn value_union(
         }
 
         // so does the namespace
-        let namespaces_match = match f.namespace() {
-            Some(s) => Some(s.as_str()) == discriminant.ident.ns(),
-            None => discriminant.ident.ns().is_none(),
-        };
+        let namespaces_match =
+            f.namespace().map(String::as_str) == Some(discriminant.ident.namespace);
         log::trace!("finding discrim... `namespaces_match: bool = {namespaces_match}`");
         if !namespaces_match {
             log::trace!(

--- a/raves_metadata/src/xmp/value/unions.rs
+++ b/raves_metadata/src/xmp/value/unions.rs
@@ -123,12 +123,12 @@ pub fn value_union(
     // find the discriminant (or err)
     let Some(found_discriminant) = expected_fields.iter().find(|f| {
         // the names have to match
-        let names_match = f.ident() == discriminant.ident.name();
+        let names_match = f.name() == discriminant.ident.name();
         log::trace!("finding discrim... `names_match: bool = {names_match}`");
         if !names_match {
             log::trace!(
                 "name for this field was: `{}`. expected: `{}`",
-                f.ident(),
+                f.name(),
                 discriminant.ident.name()
             );
         }
@@ -172,7 +172,7 @@ pub fn value_union(
 mod tests {
     use raves_metadata_types::{
         xmp::parse_types::XmpKind,
-        xmp::{XmpElement, XmpPrimitive, XmpValue, XmpValueStructField},
+        xmp::{XmpElement, XmpIdent, XmpPrimitive, XmpValue, XmpValueStructField},
     };
     use xmltree::Element;
 
@@ -219,57 +219,80 @@ mod tests {
         assert_eq!(
             parsed_union,
             XmpElement {
-                namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
-                prefix: "rdf".into(),
-                name: "li".into(),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "rdf".into(),
+                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".into(),
+                    "li".into(),
+                ),
                 value: XmpValue::Union {
                     discriminant: Box::new(XmpValueStructField::Value {
-                        ident: "mode".into(),
-                        namespace: Some("http://ns.adobe.com/xap/1.0/g/".into()),
-                        value: XmpValue::Simple(XmpPrimitive::Text("CMYK".into()))
+                        ident: XmpIdent::new_with_one_namespace_pair(
+                            "xmpG".into(),
+                            "http://ns.adobe.com/xap/1.0/g/".into(),
+                            "mode".into(),
+                        ),
+                        value: XmpValue::Simple(XmpPrimitive::Text("CMYK".into())),
                     }),
                     expected_fields: vec![
-                        // always fields: `swatchName` + `mode`
                         XmpValueStructField::Value {
-                            ident: "swatchName".into(),
-                            namespace: Some("http://ns.adobe.com/xap/1.0/g/".into()),
-                            value: XmpValue::Simple(XmpPrimitive::Text("black".into()))
+                            ident: XmpIdent::new_with_one_namespace_pair(
+                                "xmpG".into(),
+                                "http://ns.adobe.com/xap/1.0/g/".into(),
+                                "swatchName".into(),
+                            ),
+                            value: XmpValue::Simple(XmpPrimitive::Text("black".into())),
                         },
                         XmpValueStructField::Value {
-                            ident: "mode".into(),
-                            namespace: Some("http://ns.adobe.com/xap/1.0/g/".into()),
-                            value: XmpValue::Simple(XmpPrimitive::Text("CMYK".into()))
+                            ident: XmpIdent::new_with_one_namespace_pair(
+                                "xmpG".into(),
+                                "http://ns.adobe.com/xap/1.0/g/".into(),
+                                "mode".into(),
+                            ),
+                            value: XmpValue::Simple(XmpPrimitive::Text("CMYK".into())),
                         },
                         XmpValueStructField::Value {
-                            ident: "type".into(),
-                            namespace: Some("http://ns.adobe.com/xap/1.0/g/".into()),
-                            value: XmpValue::Simple(XmpPrimitive::Text("PROCESS".into()))
-                        },
-                        //
-                        // optional fields (for mode::CMYK)
-                        XmpValueStructField::Value {
-                            ident: "cyan".into(),
-                            namespace: Some("http://ns.adobe.com/xap/1.0/g/".into()),
-                            value: XmpValue::Simple(XmpPrimitive::Real(100.0))
+                            ident: XmpIdent::new_with_one_namespace_pair(
+                                "xmpG".into(),
+                                "http://ns.adobe.com/xap/1.0/g/".into(),
+                                "type".into(),
+                            ),
+                            value: XmpValue::Simple(XmpPrimitive::Text("PROCESS".into())),
                         },
                         XmpValueStructField::Value {
-                            ident: "magenta".into(),
-                            namespace: Some("http://ns.adobe.com/xap/1.0/g/".into()),
-                            value: XmpValue::Simple(XmpPrimitive::Real(100.0))
+                            ident: XmpIdent::new_with_one_namespace_pair(
+                                "xmpG".into(),
+                                "http://ns.adobe.com/xap/1.0/g/".into(),
+                                "cyan".into(),
+                            ),
+                            value: XmpValue::Simple(XmpPrimitive::Real(100.0)),
                         },
                         XmpValueStructField::Value {
-                            ident: "yellow".into(),
-                            namespace: Some("http://ns.adobe.com/xap/1.0/g/".into()),
-                            value: XmpValue::Simple(XmpPrimitive::Real(100.0))
+                            ident: XmpIdent::new_with_one_namespace_pair(
+                                "xmpG".into(),
+                                "http://ns.adobe.com/xap/1.0/g/".into(),
+                                "magenta".into(),
+                            ),
+                            value: XmpValue::Simple(XmpPrimitive::Real(100.0)),
                         },
                         XmpValueStructField::Value {
-                            ident: "black".into(),
-                            namespace: Some("http://ns.adobe.com/xap/1.0/g/".into()),
-                            value: XmpValue::Simple(XmpPrimitive::Real(100.0))
+                            ident: XmpIdent::new_with_one_namespace_pair(
+                                "xmpG".into(),
+                                "http://ns.adobe.com/xap/1.0/g/".into(),
+                                "yellow".into(),
+                            ),
+                            value: XmpValue::Simple(XmpPrimitive::Real(100.0)),
+                        },
+                        XmpValueStructField::Value {
+                            ident: XmpIdent::new_with_one_namespace_pair(
+                                "xmpG".into(),
+                                "http://ns.adobe.com/xap/1.0/g/".into(),
+                                "black".into(),
+                            ),
+                            value: XmpValue::Simple(XmpPrimitive::Real(100.0)),
                         },
                     ],
-                    unexpected_fields: vec![]
-                }
+                    unexpected_fields: vec![],
+                },
             }
         );
     }

--- a/raves_metadata/src/xmp/value/uris.rs
+++ b/raves_metadata/src/xmp/value/uris.rs
@@ -63,3 +63,228 @@ pub fn value_uri(element: &Element, maybe_ty: Option<&'static Kind>) -> XmpEleme
     // so... return an err
     Err(XmpParsingError::UriHadNoRdfResource)
 }
+
+#[cfg(test)]
+mod tests {
+    use raves_metadata_types::xmp::{
+        XmpElement, XmpValue,
+        parse_types::{XmpKind, XmpPrimitiveKind::Text},
+    };
+    use xmltree::Element;
+
+    use crate::xmp::error::XmpParsingError;
+
+    const TY: &XmpKind = &XmpKind::Uri;
+
+    #[test]
+    fn valid_uri() {
+        helpers::init_logging();
+
+        // define everything the parser needs
+        let xml = r#"<prefix:element xmlns:prefix="https://namespace.com/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:resource="https://some_link.com"/>"#;
+        let element = Element::parse(xml.as_bytes()).expect("xmltree should parse");
+
+        // test both with and without types
+        for maybe_type in [None, Some(TY)] {
+            // parse it out
+            let xmp_element: XmpElement = super::value_uri(&element, maybe_type)
+                .expect("XML element should return as expected");
+
+            assert_eq!(
+                xmp_element,
+                XmpElement {
+                    namespace: "https://namespace.com/".into(),
+                    prefix: "prefix".into(),
+                    name: "element".into(),
+                    value: XmpValue::Uri("https://some_link.com".into())
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn valid_uri_inside_inner() {
+        helpers::init_logging();
+
+        let xml = r#"<prefix:outer xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:prefix="https://namespace.com/">
+            <prefix:inner rdf:resource="https://github.com/raves-project"/>
+        </prefix:outer>"#;
+
+        let element = Element::parse(xml.as_bytes())
+            .expect("xmltree should parse")
+            .children
+            .first()
+            .and_then(|xml_node| xml_node.as_element().cloned())
+            .expect("should have child node");
+
+        // test both with and without types
+        for maybe_type in [None, Some(TY)] {
+            let xmp_element: XmpElement = super::value_uri(&element, maybe_type)
+                .expect("XML element should return as expected");
+
+            assert_eq!(
+                xmp_element,
+                XmpElement {
+                    namespace: "https://namespace.com/".into(),
+                    prefix: "prefix".into(),
+                    name: "inner".into(),
+                    value: XmpValue::Uri("https://github.com/raves-project".into())
+                }
+            );
+        }
+    }
+
+    /// The parser checks for weird URI forms.
+    ///
+    /// If a URI has children/text, and still ends up getting parsed, the
+    /// parser errors since the URI is in violation of the standard.
+    #[test]
+    fn valid_uri_with_weird_forms_should_fail() {
+        helpers::init_logging();
+
+        let xmls_and_errs = [
+            (
+                r#"<prefix:element xmlns:prefix="https://namespace.com/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:resource="https://some_link.com">SOME TEXT THAT WILL BE IGNORED</prefix:element>"#,
+                XmpParsingError::UriHadInnerText,
+            ),
+            (
+                r#"<prefix:element xmlns:prefix="https://namespace.com/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:resource="https://some_link.com"><prefix:INNER_ELEMENT /></prefix:element>"#,
+                XmpParsingError::UriHadChildren {
+                    number_of_children: 1,
+                },
+            ),
+        ];
+
+        // test both with and without types
+        for maybe_type in [None, Some(TY)] {
+            // test both weird forms
+            for (xml, expected_error) in &xmls_and_errs {
+                let element = Element::parse(xml.as_bytes()).expect("xmltree should parse");
+
+                if matches!(expected_error, XmpParsingError::UriHadChildren { .. }) {
+                    assert_eq!(element.get_text(), None);
+                }
+
+                let maybe_xmp_element = super::value_uri(&element, maybe_type);
+
+                assert_eq!(
+                    maybe_xmp_element.expect_err("child element should fail the parser"),
+                    *expected_error,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_attributes_should_fail() {
+        helpers::init_logging();
+        let xml = r#"<prefix:outer xmlns:prefix="https://namespace.com/"><prefix:inner /></prefix:outer>"#;
+        let element = Element::parse(xml.as_bytes())
+            .expect("xmltree should parse")
+            .children
+            .first()
+            .and_then(|xml_node| xml_node.as_element().cloned())
+            .expect("should have child node");
+
+        let result = super::value_uri(&element, Some(TY));
+        assert!(result.is_err_and(|e| e == XmpParsingError::UriHadNoRdfResource));
+    }
+
+    #[test]
+    fn no_rdf_attribute_should_fail() {
+        helpers::init_logging();
+
+        let xml = r#"<prefix:outer xmlns:prefix="https://namespace.com/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <prefix:inner rdf:not_resource="https://some_link.com" />
+        </prefix:outer>"#;
+
+        let element = Element::parse(xml.as_bytes())
+            .expect("xmltree should parse")
+            .children
+            .first()
+            .and_then(|xml_node| xml_node.as_element().cloned())
+            .unwrap();
+
+        let result = super::value_uri(&element, Some(TY));
+        assert!(result.is_err_and(|e| e == XmpParsingError::UriHadNoRdfResource));
+    }
+
+    #[test]
+    fn rdf_resource_attribute_with_weird_namespace_should_fail() {
+        helpers::init_logging();
+
+        let xml = r#"<prefix:outer xmlns:prefix="https://namespace.com/" xmlns:rdf="http://NOT.THE.ACTUAL/namespace">
+            <prefix:inner rdf:resource="https://some_link.com" />
+        </prefix:outer>"#;
+
+        let element = Element::parse(xml.as_bytes())
+            .expect("xmltree should parse")
+            .children
+            .first()
+            .and_then(|xml_node| xml_node.as_element().cloned())
+            .unwrap();
+
+        let result = super::value_uri(&element, Some(TY));
+        assert!(result.is_err_and(|e| e == XmpParsingError::UriHadNoRdfResource));
+    }
+
+    #[test]
+    fn rdf_resource_attribute_with_weird_prefix_but_normal_namespace_works() {
+        helpers::init_logging();
+
+        // note: the `NOT_RDF:resource` attribute should work since the
+        // namespace URL matches correctly ;D
+        let xml = r#"<prefix:outer xmlns:prefix="https://namespace.com/" xmlns:NOT_RDF="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <prefix:inner NOT_RDF:resource="https://github.com/raves-project" />
+        </prefix:outer>"#;
+
+        let element = Element::parse(xml.as_bytes())
+            .expect("xmltree should parse")
+            .children
+            .first()
+            .and_then(|xml_node| xml_node.as_element().cloned())
+            .unwrap();
+
+        // test both with and without types
+        for maybe_type in [None, Some(TY)] {
+            let xmp_element: XmpElement = super::value_uri(&element, maybe_type)
+                .expect("XML element should return as expected");
+
+            assert_eq!(
+                xmp_element,
+                XmpElement {
+                    namespace: "https://namespace.com/".into(),
+                    prefix: "prefix".into(),
+                    name: "inner".into(),
+                    value: XmpValue::Uri("https://github.com/raves-project".into())
+                }
+            );
+        }
+    }
+
+    /// When given a type that's not `Uri`, the parser should panic and warn
+    /// users about an implementation error.
+    #[test]
+    #[should_panic(
+        expected = "Type mismatch in `value_uri` function! Please report this crash to `raves_metadata`."
+    )]
+    fn unexpected_type_should_panic() {
+        helpers::init_logging();
+        let xml = r#"<prefix:element xmlns:prefix="https://namespace.com/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:resource="https://some_link.com"/>"#;
+        let element = Element::parse(xml.as_bytes()).expect("xmltree should parse");
+
+        // this should trigger a panic
+        const INVALID_TY: &XmpKind = &XmpKind::Simple(Text);
+        _ = super::value_uri(&element, Some(INVALID_TY));
+    }
+
+    mod helpers {
+        pub fn init_logging() {
+            _ = env_logger::builder()
+                .filter_level(log::LevelFilter::max())
+                .format_file(true)
+                .format_line_number(true)
+                .try_init();
+        }
+    }
+}

--- a/raves_metadata/src/xmp/value/uris.rs
+++ b/raves_metadata/src/xmp/value/uris.rs
@@ -1,0 +1,65 @@
+use xmltree::Element;
+
+use crate::xmp::{
+    error::{XmpElementResult, XmpParsingError},
+    value::XmpElementExt as _,
+};
+use raves_metadata_types::xmp::{XmpValue, parse_types::XmpKind as Kind};
+
+/// Parses an element's value as a URI.
+///
+/// In XML, a URI will look like so:
+///
+/// ```xml
+/// <ns:element rdf:resource="https://some_link.com"/>
+/// ```
+pub fn value_uri(element: &Element, maybe_ty: Option<&'static Kind>) -> XmpElementResult {
+    // if the kind doesn't match, that's our fault!
+    if let Some(ty) = maybe_ty
+        && *ty != Kind::Uri
+    {
+        log::error!(
+            "Type given to the `value_uri` function was not XmpKind::Uri! \
+            It was: `{ty:?}`. \
+            This is an internal error -- please report it to `raves_metadata`!"
+        );
+        panic!(
+            "Type mismatch in `value_uri` function! \
+            Please report this crash to `raves_metadata`."
+        );
+    }
+
+    // ensure the element has no inner text
+    if element.get_text().is_some() {
+        log::error!("Given element had inner text, but URI types cannot do that!");
+        return Err(XmpParsingError::UriHadInnerText);
+    }
+
+    // also, check that it has no children
+    if !element.children.is_empty() {
+        log::error!("Given element had children, but URI types cannot do that!");
+        return Err(XmpParsingError::UriHadChildren {
+            number_of_children: element.children.len() as u64,
+        });
+    }
+
+    // look for a URI inside the resource (it'll be in one of the attrs)
+    for (owned_name, value) in element.attributes.iter() {
+        if owned_name
+            .namespace_ref()
+            .is_some_and(|ns| ns == crate::xmp::RDF_NAMESPACE)
+            && owned_name.local_name == "resource"
+        {
+            // clone the attribute's value into an XmpValue
+            let xmp_value: XmpValue = XmpValue::Uri(value.clone());
+
+            // then, combine it w/ its element to create an XmpElement
+            return element.to_xmp_element(xmp_value);
+        }
+    }
+
+    // if no attribute matches, we didn't find anything!
+    //
+    // so... return an err
+    Err(XmpParsingError::UriHadNoRdfResource)
+}

--- a/raves_metadata/src/xmp/value/uris.rs
+++ b/raves_metadata/src/xmp/value/uris.rs
@@ -67,7 +67,7 @@ pub fn value_uri(element: &Element, maybe_ty: Option<&'static Kind>) -> XmpEleme
 #[cfg(test)]
 mod tests {
     use raves_metadata_types::xmp::{
-        XmpElement, XmpValue,
+        XmpElement, XmpIdent, XmpValue,
         parse_types::{XmpKind, XmpPrimitiveKind::Text},
     };
     use xmltree::Element;
@@ -93,10 +93,12 @@ mod tests {
             assert_eq!(
                 xmp_element,
                 XmpElement {
-                    namespace: "https://namespace.com/".into(),
-                    prefix: "prefix".into(),
-                    name: "element".into(),
-                    value: XmpValue::Uri("https://some_link.com".into())
+                    ident: XmpIdent::new_with_one_namespace_pair(
+                        "prefix".into(),
+                        "https://namespace.com/".into(),
+                        "element".into(),
+                    ),
+                    value: XmpValue::Uri("https://some_link.com".into()),
                 }
             );
         }
@@ -125,10 +127,12 @@ mod tests {
             assert_eq!(
                 xmp_element,
                 XmpElement {
-                    namespace: "https://namespace.com/".into(),
-                    prefix: "prefix".into(),
-                    name: "inner".into(),
-                    value: XmpValue::Uri("https://github.com/raves-project".into())
+                    ident: XmpIdent::new_with_one_namespace_pair(
+                        "prefix".into(),
+                        "https://namespace.com/".into(),
+                        "inner".into(),
+                    ),
+                    value: XmpValue::Uri("https://github.com/raves-project".into()),
                 }
             );
         }
@@ -253,10 +257,12 @@ mod tests {
             assert_eq!(
                 xmp_element,
                 XmpElement {
-                    namespace: "https://namespace.com/".into(),
-                    prefix: "prefix".into(),
-                    name: "inner".into(),
-                    value: XmpValue::Uri("https://github.com/raves-project".into())
+                    ident: XmpIdent::new_with_one_namespace_pair(
+                        "prefix".into(),
+                        "https://namespace.com/".into(),
+                        "inner".into(),
+                    ),
+                    value: XmpValue::Uri("https://github.com/raves-project".into()),
                 }
             );
         }

--- a/raves_metadata/src/xmp/write.rs
+++ b/raves_metadata/src/xmp/write.rs
@@ -451,3 +451,51 @@ fn sort_xmp_struct_field_list(list: &mut [XmpValueStructField]) {
             })
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_str_eq;
+
+    use crate::xmp::Xmp;
+
+    #[test]
+    fn write_round_trip() {
+        helpers::init_logging();
+
+        for i in 1..=2 {
+            // read the input from disk
+            let input_path: String = format!("assets/metadata_specs/xmp/{i}.in.xml");
+            let input_xml: String = std::fs::read_to_string(&input_path).expect("get input XML");
+
+            // parse as XMP
+            let xmp: Xmp = Xmp::new(&input_xml).expect("XMP should parse properly");
+
+            // write that XMP back to a string of XML
+            let mut output: Vec<u8> = Vec::new();
+            xmp.write(&mut output).expect("XMP should write");
+            let output_xml: &str = core::str::from_utf8(&output).expect("Output should be UTF-8");
+
+            // grab expected output
+            let expected_output_path: String = format!("assets/metadata_specs/xmp/{i}.out.xml");
+            let expected_output_xml: String =
+                std::fs::read_to_string(&expected_output_path).expect("get expected output XML");
+
+            // make sure the output is as expected
+            assert_str_eq!(
+                expected_output_xml,
+                output_xml,
+                "Round trip for test file at: `{expected_output_path}` failed! (LEFT: expected, RIGHT: got)"
+            );
+        }
+    }
+
+    mod helpers {
+        pub fn init_logging() {
+            _ = env_logger::builder()
+                .filter_level(log::LevelFilter::max())
+                .format_file(true)
+                .format_line_number(true)
+                .try_init();
+        }
+    }
+}

--- a/raves_metadata/src/xmp/write.rs
+++ b/raves_metadata/src/xmp/write.rs
@@ -5,29 +5,10 @@ use raves_metadata_types::xmp::{
 };
 use xmltree::{AttributeName, Element, Namespace, XMLNode};
 
-use crate::xmp::{RDF_NAMESPACE, X_NAMESPACE, Xmp};
-
-#[derive(Debug)]
-pub enum todo_write_error_move_me {
-    /// The underlying XML writer failed to write the document.
-    ///
-    /// This could be due to a number of reasons, though it's likely due to the
-    /// destination referred to by `Write` being unavailable.
-    ///
-    /// Please see the contained error's `Display` output for more info.
-    XmlWriteError(xmltree::Error),
-
-    /// The depth limit has been reached.
-    ///
-    /// In other words, there were, recursively, too many fields.
-    DepthLimitReached(u8),
-}
-
-pub struct todo_impl_display_for_err;
-pub struct todo_impl_error_for_err;
+use crate::xmp::{RDF_NAMESPACE, X_NAMESPACE, Xmp, error::XmpWriteError};
 
 impl Xmp {
-    pub fn write<W: std::io::Write>(&self, w: &mut W) -> Result<(), todo_write_error_move_me> {
+    pub fn write<W: std::io::Write>(&self, w: &mut W) -> Result<(), XmpWriteError> {
         // convert the XMP data to an XML document
         log::trace!("Converting XMP to XML...");
         let root: Element = xmp_data_to_xml_document(self)?;
@@ -35,22 +16,36 @@ impl Xmp {
 
         // write root using `Write` trait
         log::trace!("Writing XML document to sink...");
-        root.write_with_config(
-            w,
-            xmltree::EmitterConfig {
-                indent_string: std::borrow::Cow::from("    "),
-                perform_indent: true,
-                ..Default::default()
-            },
-        )
-        .inspect_err(|e| log::error!("Failed to write XMP as XML due to error: {e}"))
-        .map_err(todo_write_error_move_me::XmlWriteError)
-        .inspect(|_| log::trace!("XML document was successfully written to sink!"))
+        let result = root
+            .write_with_config(
+                w,
+                xmltree::EmitterConfig {
+                    indent_string: std::borrow::Cow::from("    "),
+                    perform_indent: true,
+                    ..Default::default()
+                },
+            )
+            .inspect_err(|e| log::error!("Failed to write XMP as XML due to error: {e}"))
+            .inspect(|_| log::trace!("XML document was successfully written to sink!"));
+
+        // convert any error to our crate's error (via string conversion).
+        //
+        // otherwise, return `Ok`!
+        match result {
+            // NOTE: these are strings to let the error type impl `Clone`/etc.
+            Err(xmltree::Error::Io(io)) => Err(XmpWriteError::Io(io.to_string())),
+            Err(other) => {
+                // TODO: is this even possible? we maintain the XML model lol
+                Err(XmpWriteError::XmlWrite(other.to_string()))
+            }
+
+            Ok(()) => Ok(()),
+        }
     }
 }
 
 /// Creates an XML document from the inner XMP data.
-fn xmp_data_to_xml_document(xmp: &Xmp) -> Result<Element, todo_write_error_move_me> {
+fn xmp_data_to_xml_document(xmp: &Xmp) -> Result<Element, XmpWriteError> {
     // XMP's flavor of XML has the following layout:
     //
     // - x:xmpmeta
@@ -97,7 +92,7 @@ fn xmp_data_to_xml_document(xmp: &Xmp) -> Result<Element, todo_write_error_move_
 
     for value in sorted_values {
         // convert it to an XML element
-        let xml_element: Element = convert_xmp_element_to_xml_element(&value, 0)?;
+        let xml_element: Element = convert_xmp_element_to_xml_element(&value)?;
 
         // then, append the XML element to the `rdf:Description`
         description.children.push(XMLNode::Element(xml_element));
@@ -112,14 +107,7 @@ fn xmp_data_to_xml_document(xmp: &Xmp) -> Result<Element, todo_write_error_move_
 
 fn convert_xmp_element_to_xml_element(
     xmp_src_element: &XmpElement,
-    depth: u8,
-) -> Result<Element, todo_write_error_move_me> {
-    // ensure we're not past the depth limit (for recursive calls)
-    if depth == u8::MAX {
-        log::error!("XML depth limit reached! Cannot continue writing...");
-        return Err(todo_write_error_move_me::DepthLimitReached(u8::MAX));
-    }
-
+) -> Result<Element, XmpWriteError> {
     // create a new XML element
     let mut xml_dest_element = Element::new(xmp_src_element.ident.name.as_str());
 
@@ -166,7 +154,7 @@ fn convert_xmp_element_to_xml_element(
 
             // add each field onto the struct
             for field in fields {
-                add_struct_field_to_element(&mut description, &field, depth)?;
+                add_struct_field_to_element(&mut description, &field)?;
             }
 
             // push the `rdf:Description` onto the parent
@@ -192,11 +180,11 @@ fn convert_xmp_element_to_xml_element(
             let mut description: Element = create_rdf_description_element();
 
             // add discriminant
-            add_struct_field_to_element(&mut description, &discriminant.clone(), depth)?;
+            add_struct_field_to_element(&mut description, &discriminant.clone())?;
 
             // add expected fields
             for field in expected_fields {
-                add_struct_field_to_element(&mut description, &field, depth)?;
+                add_struct_field_to_element(&mut description, &field)?;
             }
 
             // finally, add unexpected fields
@@ -206,7 +194,7 @@ fn convert_xmp_element_to_xml_element(
                     field.namespace(),
                     field.name()
                 );
-                add_struct_field_to_element(&mut description, &field, depth)?;
+                add_struct_field_to_element(&mut description, &field)?;
             }
 
             // push the `rdf:Description` onto the parent
@@ -236,7 +224,7 @@ fn convert_xmp_element_to_xml_element(
 
             // push each list value onto the `rdf:Bag`
             for element in xmp_elements {
-                add_array_entry_to_element(&mut bag, &element.value, None, depth)?;
+                add_array_entry_to_element(&mut bag, &element.value, None)?;
             }
 
             // push the `rdf:Bag` onto the parent
@@ -259,7 +247,7 @@ fn convert_xmp_element_to_xml_element(
 
             // push each list value onto the `rdf:Seq`
             for element in xmp_elements {
-                add_array_entry_to_element(&mut seq, &element.value, None, depth)?;
+                add_array_entry_to_element(&mut seq, &element.value, None)?;
             }
 
             // push the `rdf:Seq` onto the parent
@@ -287,7 +275,6 @@ fn convert_xmp_element_to_xml_element(
                     &mut alt,
                     &XmpValue::Simple(XmpPrimitive::Text(alternative.text.clone())),
                     Some(alternative_lang),
-                    depth,
                 )?;
             }
 
@@ -340,8 +327,7 @@ fn create_rdf_description_element() -> Element {
 fn add_struct_field_to_element(
     description: &mut Element,
     field: &XmpValueStructField,
-    depth: u8,
-) -> Result<(), todo_write_error_move_me> {
+) -> Result<(), XmpWriteError> {
     description
         .children
         .push(XMLNode::Element(convert_xmp_element_to_xml_element(
@@ -353,7 +339,6 @@ fn add_struct_field_to_element(
                     value: value.clone(),
                 },
             },
-            depth + 1,
         )?));
 
     Ok(())
@@ -368,8 +353,7 @@ fn add_array_entry_to_element(
     parent: &mut Element,
     value: &XmpValue,
     lang_qualifier: Option<&str>,
-    depth: u8,
-) -> Result<(), todo_write_error_move_me> {
+) -> Result<(), XmpWriteError> {
     // make a `xml:lang` qualifier for `rdf:li`, if needed
     let attributes: HashMap<xmltree::AttributeName, String> =
         if let Some(qualifier) = lang_qualifier {
@@ -386,17 +370,14 @@ fn add_array_entry_to_element(
         };
 
     // create a `rdf:li` item that **is** the content
-    let mut li: Element = convert_xmp_element_to_xml_element(
-        &XmpElement {
-            ident: XmpIdent::new_with_one_namespace_pair(
-                "rdf".into(),
-                RDF_NAMESPACE.into(),
-                "li".into(),
-            ),
-            value: value.clone(),
-        },
-        depth + 1,
-    )?;
+    let mut li: Element = convert_xmp_element_to_xml_element(&XmpElement {
+        ident: XmpIdent::new_with_one_namespace_pair(
+            "rdf".into(),
+            RDF_NAMESPACE.into(),
+            "li".into(),
+        ),
+        value: value.clone(),
+    })?;
     li.attributes = attributes;
 
     parent.children.push(XMLNode::Element(li));
@@ -454,9 +435,9 @@ fn sort_xmp_struct_field_list(list: &mut [XmpValueStructField]) {
 
 #[cfg(test)]
 mod tests {
-    use pretty_assertions::assert_str_eq;
+    use pretty_assertions::{assert_eq, assert_str_eq};
 
-    use crate::xmp::Xmp;
+    use crate::xmp::{Xmp, error::XmpWriteError};
 
     #[test]
     fn write_round_trip() {
@@ -487,6 +468,31 @@ mod tests {
                 "Round trip for test file at: `{expected_output_path}` failed! (LEFT: expected, RIGHT: got)"
             );
         }
+    }
+
+    #[test]
+    fn write_to_full_buffer_should_fail() {
+        helpers::init_logging();
+
+        // define a limited-size buf
+        let mut buffer: [u8; 32] = [0_u8; 32];
+
+        // grab input XML
+        let input_path = r#"assets/metadata_specs/xmp/1.in.xml"#;
+        let input_xml: String = std::fs::read_to_string(input_path).expect("get input XML");
+
+        // parse as XMP
+        let xmp: Xmp = Xmp::new(&input_xml).expect("XMP should parse properly");
+
+        // write that XMP back to a string of XML
+        let error: XmpWriteError = xmp
+            .write(&mut buffer.as_mut_slice())
+            .expect_err("buffer is full, so write should fail");
+
+        assert_eq!(
+            error,
+            XmpWriteError::Io("failed to write whole buffer".into())
+        );
     }
 
     mod helpers {

--- a/raves_metadata/src/xmp/write.rs
+++ b/raves_metadata/src/xmp/write.rs
@@ -8,6 +8,60 @@ use xmltree::{AttributeName, Element, Namespace, XMLNode};
 use crate::xmp::{RDF_NAMESPACE, X_NAMESPACE, Xmp, error::XmpWriteError};
 
 impl Xmp {
+    /// Writes XMP metadata out as XML.
+    ///
+    /// The given `W`, a `std::io::Write` implementor, acts as a buffer to
+    /// store the resulting XML. This buffer would usually be a file, but you
+    /// may use any type you'd like!
+    ///
+    /// ```
+    /// use raves_metadata::xmp::{
+    ///     types::{XmpElement, XmpPrimitive, XmpValue},
+    ///     Xmp,
+    /// };
+    ///
+    /// // input some XMP XML.
+    /// //
+    /// // you can get this from a provider, instead, like JPEG or MP4!
+    /// let input_xml: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+    /// <x:xmpmeta xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:x="adobe:ns:meta/">
+    ///     <rdf:RDF>
+    ///         <rdf:Description rdf:about="">
+    ///             <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">
+    ///                 <rdf:Bag>
+    ///                     <rdf:li>`raves_metadata`</rdf:li>
+    ///                 </rdf:Bag>
+    ///             </dc:subject>
+    ///         </rdf:Description>
+    ///     </rdf:RDF>
+    /// </x:xmpmeta>"#;
+    ///
+    /// // parse the XMP
+    /// let xmp: Xmp = Xmp::new(input_xml).expect("the given XMP should parse correctly");
+    /// let element: &XmpElement = xmp
+    ///     .document()
+    ///     .values_ref()
+    ///     .first()
+    ///     .expect("there should be a value in here");
+    ///
+    /// // should be equal to: ["`raves_metadata`"]
+    /// let XmpValue::UnorderedArray(ref v) = element.value else {
+    ///     panic!("Error: not an unordered array!");
+    /// };
+    /// assert_eq!(
+    ///     v.first().unwrap().value,
+    ///     XmpValue::Simple(XmpPrimitive::Text("`raves_metadata`".into()))
+    /// );
+    ///
+    /// // now, write the XMP back to XML
+    /// let mut output_xml_bytes: Vec<u8> = Vec::new();
+    /// xmp.write(&mut output_xml_bytes)
+    ///     .expect("XMP should write properly");
+    /// let output_xml: String = String::from_utf8(output_xml_bytes).expect("it's UTF-8");
+    ///
+    /// // the output should perfectly equal the input
+    /// assert_eq!(output_xml, input_xml);
+    /// ```
     pub fn write<W: std::io::Write>(&self, w: &mut W) -> Result<(), XmpWriteError> {
         // convert the XMP data to an XML document
         log::trace!("Converting XMP to XML...");

--- a/raves_metadata/src/xmp/write.rs
+++ b/raves_metadata/src/xmp/write.rs
@@ -1,0 +1,453 @@
+use std::collections::{BTreeMap, HashMap};
+
+use raves_metadata_types::xmp::{
+    XmpElement, XmpIdent, XmpPrimitive, XmpValue, XmpValueStructField,
+};
+use xmltree::{AttributeName, Element, Namespace, XMLNode};
+
+use crate::xmp::{RDF_NAMESPACE, X_NAMESPACE, Xmp};
+
+#[derive(Debug)]
+pub enum todo_write_error_move_me {
+    /// The underlying XML writer failed to write the document.
+    ///
+    /// This could be due to a number of reasons, though it's likely due to the
+    /// destination referred to by `Write` being unavailable.
+    ///
+    /// Please see the contained error's `Display` output for more info.
+    XmlWriteError(xmltree::Error),
+
+    /// The depth limit has been reached.
+    ///
+    /// In other words, there were, recursively, too many fields.
+    DepthLimitReached(u8),
+}
+
+pub struct todo_impl_display_for_err;
+pub struct todo_impl_error_for_err;
+
+impl Xmp {
+    pub fn write<W: std::io::Write>(&self, w: &mut W) -> Result<(), todo_write_error_move_me> {
+        // convert the XMP data to an XML document
+        log::trace!("Converting XMP to XML...");
+        let root: Element = xmp_data_to_xml_document(self)?;
+        log::trace!("XMP was successfully converted to an XML document!");
+
+        // write root using `Write` trait
+        log::trace!("Writing XML document to sink...");
+        root.write_with_config(
+            w,
+            xmltree::EmitterConfig {
+                indent_string: std::borrow::Cow::from("    "),
+                perform_indent: true,
+                ..Default::default()
+            },
+        )
+        .inspect_err(|e| log::error!("Failed to write XMP as XML due to error: {e}"))
+        .map_err(todo_write_error_move_me::XmlWriteError)
+        .inspect(|_| log::trace!("XML document was successfully written to sink!"))
+    }
+}
+
+/// Creates an XML document from the inner XMP data.
+fn xmp_data_to_xml_document(xmp: &Xmp) -> Result<Element, todo_write_error_move_me> {
+    // XMP's flavor of XML has the following layout:
+    //
+    // - x:xmpmeta
+    //  - rdf:RDF
+    //    - rdf:Description
+    //      - (all parsed/written values stored in the XmpDocument)
+    //
+    // first, create and configure the `x:xmpmeta` element
+    let mut xmpmeta: Element = Element::new("xmpmeta");
+    xmpmeta.namespace = Some(X_NAMESPACE.into());
+    xmpmeta.namespaces = Some(Namespace({
+        BTreeMap::from([
+            // (prefix, uri)
+            ("x".into(), X_NAMESPACE.into()),
+            ("rdf".into(), RDF_NAMESPACE.into()),
+        ])
+    }));
+    xmpmeta.prefix = Some("x".into());
+
+    // now, create the `rdf:RDF` element
+    let mut rdf: Element = Element::new("RDF");
+    rdf.namespace = Some(RDF_NAMESPACE.into());
+    rdf.namespaces = Some(Namespace({
+        BTreeMap::from([("rdf".into(), RDF_NAMESPACE.into())])
+    }));
+    rdf.prefix = Some("rdf".into());
+
+    // and the `rdf:Description`.
+    //
+    // note that it must have the `rdf:about=""` attribute on it
+    let mut description: Element = create_rdf_description_element();
+    _ = description.attributes.insert(
+        AttributeName {
+            local_name: "about".into(),
+            namespace: Some(RDF_NAMESPACE.into()),
+            prefix: Some("rdf".into()),
+        },
+        String::new(),
+    );
+
+    // dump all the children into the `rdf:Description`
+    let mut sorted_values = xmp.document().values_ref().to_vec();
+    sort_xmp_element_list(&mut sorted_values);
+
+    for value in sorted_values {
+        // convert it to an XML element
+        let xml_element: Element = convert_xmp_element_to_xml_element(&value, 0)?;
+
+        // then, append the XML element to the `rdf:Description`
+        description.children.push(XMLNode::Element(xml_element));
+    }
+
+    // finally, write each layer into its parent
+    rdf.children.push(XMLNode::Element(description));
+    xmpmeta.children.push(XMLNode::Element(rdf));
+
+    Ok(xmpmeta)
+}
+
+fn convert_xmp_element_to_xml_element(
+    xmp_src_element: &XmpElement,
+    depth: u8,
+) -> Result<Element, todo_write_error_move_me> {
+    // ensure we're not past the depth limit (for recursive calls)
+    if depth == u8::MAX {
+        log::error!("XML depth limit reached! Cannot continue writing...");
+        return Err(todo_write_error_move_me::DepthLimitReached(u8::MAX));
+    }
+
+    // create a new XML element
+    let mut xml_dest_element = Element::new(xmp_src_element.ident.name.as_str());
+
+    // add important element identifiers
+    xml_dest_element.prefix = Some(xmp_src_element.ident.prefix.clone());
+    xml_dest_element.namespace = xmp_src_element
+        .ident
+        .namespaces
+        .get(&xmp_src_element.ident.prefix)
+        .cloned();
+    xml_dest_element.namespaces = Some(Namespace(xmp_src_element.ident.namespaces.clone()));
+
+    // based on which kind of value we've got, we'll do different things!
+    //
+    // for example, `Simple` values only require extracting the inner string
+    // and writing it to the `xml_dest_element` :)
+    match &xmp_src_element.value {
+        // `Simple` values are really easy to write!
+        //
+        // just convert to a string
+        XmpValue::Simple(xmp_primitive) => {
+            xml_dest_element
+                .children
+                .push(XMLNode::Text(match xmp_primitive {
+                    XmpPrimitive::Boolean(b) => if *b { "True" } else { "False" }.into(),
+                    XmpPrimitive::Date(s) | XmpPrimitive::Text(s) => s.clone(),
+                    XmpPrimitive::Integer(i) => i.to_string(),
+                    XmpPrimitive::Real(s) => s.to_string(),
+                }));
+        }
+
+        // for structs, we must:
+        //
+        // - add an inner `rdf:Description` element
+        // - write all fields as child elements on that
+        //   - this requires calling _this_ function recursively, by the way
+        XmpValue::Struct(fields) => {
+            // clone and sort fields
+            let mut fields = fields.clone();
+            sort_xmp_struct_field_list(&mut fields);
+
+            // create `rdf:Description`
+            let mut description: Element = create_rdf_description_element();
+
+            // add each field onto the struct
+            for field in fields {
+                add_struct_field_to_element(&mut description, &field, depth)?;
+            }
+
+            // push the `rdf:Description` onto the parent
+            xml_dest_element
+                .children
+                .push(XMLNode::Element(description));
+        }
+
+        // unions are just like structs, but we also worry about the
+        // discriminant
+        XmpValue::Union {
+            discriminant,
+            expected_fields,
+            unexpected_fields,
+        } => {
+            // clone and sort fields
+            let (mut expected_fields, mut unexpected_fields) =
+                (expected_fields.clone(), unexpected_fields.clone());
+            sort_xmp_struct_field_list(&mut expected_fields);
+            sort_xmp_struct_field_list(&mut unexpected_fields);
+
+            // create `rdf:Description`
+            let mut description: Element = create_rdf_description_element();
+
+            // add discriminant
+            add_struct_field_to_element(&mut description, &discriminant.clone(), depth)?;
+
+            // add expected fields
+            for field in expected_fields {
+                add_struct_field_to_element(&mut description, &field, depth)?;
+            }
+
+            // finally, add unexpected fields
+            for field in unexpected_fields {
+                log::debug!(
+                    "Adding unexpected field ({:?}, {}) to union value...",
+                    field.namespace(),
+                    field.name()
+                );
+                add_struct_field_to_element(&mut description, &field, depth)?;
+            }
+
+            // push the `rdf:Description` onto the parent
+            xml_dest_element
+                .children
+                .push(XMLNode::Element(description));
+        }
+
+        // unordered arrays have an `rdf:Bag` container with `rdf:li` elements
+        // underneath
+        XmpValue::UnorderedArray(xmp_elements) => {
+            // clone and sort XMP elements
+            let mut xmp_elements = xmp_elements.clone();
+            sort_xmp_element_list(&mut xmp_elements);
+
+            // create the `rdf:Bag`
+            let mut bag: Element = Element {
+                prefix: Some("rdf".into()),
+                name: "Bag".into(),
+                namespace: Some(RDF_NAMESPACE.into()),
+                namespaces: Some(Namespace({
+                    BTreeMap::from([("rdf".into(), RDF_NAMESPACE.into())])
+                })),
+                attributes: Default::default(),
+                children: Default::default(),
+            };
+
+            // push each list value onto the `rdf:Bag`
+            for element in xmp_elements {
+                add_array_entry_to_element(&mut bag, &element.value, None, depth)?;
+            }
+
+            // push the `rdf:Bag` onto the parent
+            xml_dest_element.children.push(XMLNode::Element(bag));
+        }
+
+        // same as unordered array, but uses `rdf:Seq` as a container
+        XmpValue::OrderedArray(xmp_elements) => {
+            // create the `rdf:Seq`
+            let mut seq: Element = Element {
+                prefix: Some("rdf".into()),
+                name: "Seq".into(),
+                namespace: Some(RDF_NAMESPACE.into()),
+                namespaces: Some(Namespace({
+                    BTreeMap::from([("rdf".into(), RDF_NAMESPACE.into())])
+                })),
+                attributes: Default::default(),
+                children: Default::default(),
+            };
+
+            // push each list value onto the `rdf:Seq`
+            for element in xmp_elements {
+                add_array_entry_to_element(&mut seq, &element.value, None, depth)?;
+            }
+
+            // push the `rdf:Seq` onto the parent
+            xml_dest_element.children.push(XMLNode::Element(seq));
+        }
+
+        // a list of alternatives uses the `xml:lang` attribute/qualifier to
+        // create a list of possible values.
+        XmpValue::Alternatives { list } => {
+            // create the `rdf:Alt`
+            let mut alt: Element = Element {
+                prefix: Some("rdf".into()),
+                name: "Alt".into(),
+                namespace: Some(RDF_NAMESPACE.into()),
+                namespaces: Some(Namespace({
+                    BTreeMap::from([("rdf".into(), RDF_NAMESPACE.into())])
+                })),
+                attributes: Default::default(),
+                children: Default::default(),
+            };
+
+            // push each alternative to the alt element (as an `rdf:li`)
+            for (alternative_lang, alternative) in list {
+                add_array_entry_to_element(
+                    &mut alt,
+                    &XmpValue::Simple(XmpPrimitive::Text(alternative.text.clone())),
+                    Some(alternative_lang),
+                    depth,
+                )?;
+            }
+
+            // push the `rdf:Alt` element to the parent
+            xml_dest_element.children.push(XMLNode::Element(alt));
+        }
+
+        // a URI string is placed directly on the parent
+        XmpValue::Uri(uri) => {
+            _ = xml_dest_element.attributes.insert(
+                xmltree::AttributeName {
+                    local_name: "resource".into(),
+                    namespace: Some(RDF_NAMESPACE.into()),
+                    prefix: Some("rdf".into()),
+                },
+                uri.clone(),
+            );
+        }
+    }
+
+    Ok(xml_dest_element)
+}
+
+/// Creates an `rdf:Description` XML element, as that seems to be pretty
+/// common throughout all of this.
+fn create_rdf_description_element() -> Element {
+    Element {
+        // set the prefix and name.
+        //
+        // <prefix:name> means this is <rdf:Description>
+        prefix: Some("rdf".into()),
+        name: "Description".into(),
+
+        // namespace just includes the RDF namespace
+        namespace: Some(RDF_NAMESPACE.into()),
+        namespaces: Some(Namespace({
+            BTreeMap::from([("rdf".into(), RDF_NAMESPACE.into())])
+        })),
+
+        // empty attrs/children
+        attributes: Default::default(),
+        children: Default::default(),
+    }
+}
+
+/// Given an `xmltree::Element` (the `rdf:Description`) and a struct field, this
+/// function adds the fields onto the `Element` as children.
+///
+/// No distinction between struct and union is made here.
+fn add_struct_field_to_element(
+    description: &mut Element,
+    field: &XmpValueStructField,
+    depth: u8,
+) -> Result<(), todo_write_error_move_me> {
+    description
+        .children
+        .push(XMLNode::Element(convert_xmp_element_to_xml_element(
+            &match field {
+                XmpValueStructField::Element(field_xmp_element) => field_xmp_element.clone(),
+
+                XmpValueStructField::Value { ident, value } => XmpElement {
+                    ident: ident.clone(),
+                    value: value.clone(),
+                },
+            },
+            depth + 1,
+        )?));
+
+    Ok(())
+}
+
+/// Given a parent `xmltree:Element`, this function creates an `rdf:li`,
+/// appends the given `element: XmpElement` to that `rdf:li`, then finishes off
+/// by appending the `rdf:li` to the parent, such as `rdf:Bag`.
+///
+/// Created for any array type.
+fn add_array_entry_to_element(
+    parent: &mut Element,
+    value: &XmpValue,
+    lang_qualifier: Option<&str>,
+    depth: u8,
+) -> Result<(), todo_write_error_move_me> {
+    // make a `xml:lang` qualifier for `rdf:li`, if needed
+    let attributes: HashMap<xmltree::AttributeName, String> =
+        if let Some(qualifier) = lang_qualifier {
+            HashMap::from([(
+                xmltree::AttributeName {
+                    local_name: "lang".into(),
+                    namespace: None,
+                    prefix: Some("xml".into()),
+                },
+                qualifier.to_string(),
+            )])
+        } else {
+            HashMap::new()
+        };
+
+    // create a `rdf:li` item that **is** the content
+    let mut li: Element = convert_xmp_element_to_xml_element(
+        &XmpElement {
+            ident: XmpIdent::new_with_one_namespace_pair(
+                "rdf".into(),
+                RDF_NAMESPACE.into(),
+                "li".into(),
+            ),
+            value: value.clone(),
+        },
+        depth + 1,
+    )?;
+    li.attributes = attributes;
+
+    parent.children.push(XMLNode::Element(li));
+    Ok(())
+}
+
+/// Given a list of XMP elements, sorts that list using the element prefixes
+/// and names.
+fn sort_xmp_element_list(list: &mut [XmpElement]) {
+    list.sort_unstable_by(|a, b| {
+        a.ident
+            .prefix
+            .cmp(&b.ident.prefix)
+            .then_with(|| a.ident.name.cmp(&b.ident.name))
+            .then_with(|| {
+                a.value
+                    .partial_cmp(&b.value)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
+}
+
+/// Given a list of XMP struct fields, sorts that list using the element
+/// prefixes and names.
+fn sort_xmp_struct_field_list(list: &mut [XmpValueStructField]) {
+    list.sort_unstable_by(|a, b| {
+        fn get_ident(f: &XmpValueStructField) -> &XmpIdent {
+            match f {
+                XmpValueStructField::Element(xmp_element) => &xmp_element.ident,
+                XmpValueStructField::Value { ident, value: _ } => ident,
+            }
+        }
+
+        fn get_value(f: &XmpValueStructField) -> &XmpValue {
+            match f {
+                XmpValueStructField::Element(xmp_element) => &xmp_element.value,
+                XmpValueStructField::Value { ident: _, value } => value,
+            }
+        }
+
+        let (a_ident, b_ident) = (get_ident(a), get_ident(b));
+        let (a_value, b_value) = (get_value(a), get_value(b));
+
+        a_ident
+            .prefix
+            .cmp(&b_ident.prefix)
+            .then_with(|| a_ident.name.cmp(&b_ident.name))
+            .then_with(|| {
+                a_value
+                    .partial_cmp(b_value)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
+}

--- a/raves_metadata/tests/xmp.rs
+++ b/raves_metadata/tests/xmp.rs
@@ -2,6 +2,7 @@ use raves_metadata::xmp::{
     Xmp,
     types::{XmpPrimitive, XmpValue, XmpValueStructField},
 };
+use raves_metadata_types::xmp::XmpIdent;
 
 /// Checks that a known struct type parses correctly.
 #[test]
@@ -35,29 +36,38 @@ fn known_struct_type() {
         panic!("not a struct! got: {maybe_struct_val:#?}");
     };
 
-    s.sort_by_key(|field| field.ident().to_string());
+    s.sort_by_key(|field| field.name().to_string());
 
     // ensure the values are correct
     assert_eq!(s, {
         let mut v = vec![
             XmpValueStructField::Value {
-                ident: "w".into(),
-                namespace: Some(r"http://ns.adobe.com/xap/1.0/sType/Dimensions#".into()),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "stDim".into(),
+                    r"http://ns.adobe.com/xap/1.0/sType/Dimensions#".into(),
+                    "w".into(),
+                ),
                 value: XmpValue::Simple(XmpPrimitive::Real(4.0)),
             },
             XmpValueStructField::Value {
-                ident: "h".into(),
-                namespace: Some(r"http://ns.adobe.com/xap/1.0/sType/Dimensions#".into()),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "stDim".into(),
+                    r"http://ns.adobe.com/xap/1.0/sType/Dimensions#".into(),
+                    "h".into(),
+                ),
                 value: XmpValue::Simple(XmpPrimitive::Real(3.0)),
             },
             XmpValueStructField::Value {
-                ident: "unit".into(),
-                namespace: Some(r"http://ns.adobe.com/xap/1.0/sType/Dimensions#".into()),
+                ident: XmpIdent::new_with_one_namespace_pair(
+                    "stDim".into(),
+                    r"http://ns.adobe.com/xap/1.0/sType/Dimensions#".into(),
+                    "unit".into(),
+                ),
                 value: XmpValue::Simple(XmpPrimitive::Text("inch".into())),
             },
         ];
 
-        v.sort_by_key(|field| field.ident().to_string());
+        v.sort_by_key(|field| field.name().to_string());
         v
     });
 }

--- a/raves_metadata_types/CHANGELOG.typ
+++ b/raves_metadata_types/CHANGELOG.typ
@@ -2,6 +2,14 @@
 
 This file is ordered from newest to oldest.
 
+== v0.1.0
+
+- Add `XmpIdent` type.
+- Require namespaces for XMP structs.
+- Add prefix field for XMP types.
+  - This addition permits writing default prefixes for types in our parse table.
+- Create new `XmpValue` variant, `XmpValue::Uri`, as value-like URI/URLs must be parsed in a specific way.
+
 == v0.0.2
 
 - Move IPTC type generation to a new manually evoked script.

--- a/raves_metadata_types/Cargo.toml
+++ b/raves_metadata_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raves_metadata_types"
 description = "Types for parsing media metadata in `raves_metadata`"
-version = "0.0.2"
+version = "0.1.0"
 
 # derive some props from the workspace
 authors.workspace = true

--- a/raves_metadata_types/src/xmp/mod.rs
+++ b/raves_metadata_types/src/xmp/mod.rs
@@ -24,8 +24,15 @@ pub struct XmpElement {
 /// All the possible types an XMP value may have.
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub enum XmpValue {
+    /// A "simple" XMP value is a primitive that can be parsed directly as a
+    /// string, usually with a range of valid storage options.
     Simple(XmpPrimitive),
-    Struct(Vec<XmpValueStructField>),
+
+    /// A struct contains some fields.
+    Struct(
+        /// The stored fields.
+        Vec<XmpValueStructField>,
+    ),
 
     /// A union is similar to a struct, but its tag determines which fields
     /// are stored at the moment.
@@ -61,6 +68,12 @@ pub enum XmpValue {
         /// Each entry is a `(key, value)` pair.
         list: Vec<(String, XmpElement)>,
     },
+
+    /// This variant codes specifically for URIs.
+    ///
+    /// It's necessary due to the XMP standard's URIs/URLs parsing
+    /// requirements. (see: ISO 16684-1:2012, section 7.5)
+    Uri(String),
 }
 
 impl core::hash::Hash for XmpValue {
@@ -90,6 +103,7 @@ impl core::hash::Hash for XmpValue {
                 chosen.hash(state);
                 list.hash(state);
             }
+            XmpValue::Uri(string) => string.hash(state),
         }
     }
 }

--- a/raves_metadata_types/src/xmp/mod.rs
+++ b/raves_metadata_types/src/xmp/mod.rs
@@ -99,16 +99,10 @@ pub enum XmpValue {
     UnorderedArray(Vec<XmpElement>),
     OrderedArray(Vec<XmpElement>),
     Alternatives {
-        /// In `(default_key, default_value)` form.
-        ///
-        /// This is the "chosen" (default) value in the list of
-        /// alternatives.
-        chosen: (String, Box<XmpElement>),
-
         /// This is the full list of alternatives.
         ///
-        /// Each entry is a `(key, value)` pair.
-        list: Vec<(String, XmpElement)>,
+        /// Each entry is a `(lang, associated_text)` key-value pair.
+        list: BTreeMap<String, XmpValueAlternative>,
     },
 
     /// This variant codes specifically for URIs.
@@ -141,10 +135,7 @@ impl core::hash::Hash for XmpValue {
             XmpValue::UnorderedArray(xmp_elements) | XmpValue::OrderedArray(xmp_elements) => {
                 xmp_elements.hash(state)
             }
-            XmpValue::Alternatives { chosen, list } => {
-                chosen.hash(state);
-                list.hash(state);
-            }
+            XmpValue::Alternatives { list } => list.hash(state),
             XmpValue::Uri(string) => string.hash(state),
         }
     }
@@ -192,6 +183,18 @@ impl XmpValueStructField {
             XmpValueStructField::Value { ident, value: _ } => ident.namespaces.get(&ident.prefix),
         }
     }
+}
+
+/// An XMP alternative value must be a `XmpElement::Simple(XmpValue::Text(t))`,
+/// which isn't easy to enforce without a separate type.
+///
+/// So, this type exists to enforce that requirement at compile time.
+///
+/// For more information, please see: ISO 16684-1:2012, section 8.2.2
+#[derive(Clone, Debug, PartialEq, PartialOrd, Hash)]
+pub struct XmpValueAlternative {
+    /// The stored text inside the alternative.
+    pub text: String,
 }
 
 /// XMP structures can use these primitive types.

--- a/raves_metadata_types/src/xmp/mod.rs
+++ b/raves_metadata_types/src/xmp/mod.rs
@@ -3,21 +3,63 @@
 //! When parsing data out of XMP, these types, alongside the original document,
 //! are stored for user discoverability.
 
+use std::collections::BTreeMap;
+
 use ::alloc::{boxed::Box, vec::Vec};
 
 pub mod parse_table;
 pub mod parse_types;
 pub mod types;
 
+/// Stores the prefix, name, and namespaces for an XMP element.
+#[derive(Clone, Debug, PartialEq, PartialOrd, Hash)]
+pub struct XmpIdent {
+    /// The prefix of an element, such as `aaa` in `<aaa:bb />`.
+    pub prefix: String,
+
+    /// The namespace URIs per prefix at this level:
+    ///
+    /// `[(prefix, namespace_uri), (...)]`
+    ///
+    /// Layout-wise, each value is defined on any element above this one, or
+    /// this element itself, in an attribute called `xmlns:prefix`.
+    ///
+    /// For example, `aaa` might have a namespace URI of
+    /// `https://github.com/raves-project` for an XML input that looks like:
+    ///
+    /// ```xml
+    /// <some:Parent xmlns:aaa="https://github.com/raves-project" xmlns:some="http://some.com">
+    ///     <aaa:bb />
+    /// </some:Parent>
+    /// ```
+    pub namespaces: BTreeMap<String, String>,
+
+    /// The ("local") name of an element would be `bb` in `<aaa:bb />`.
+    pub name: String,
+}
+
+impl XmpIdent {
+    /// Creates a new `XmpIdent`, handling the manual creation of a `BTreeMap`
+    /// automatically.
+    pub fn new_with_one_namespace_pair(
+        prefix: String,
+        namespace_uri: String,
+        name: String,
+    ) -> Self {
+        Self {
+            name,
+            namespaces: BTreeMap::from([(prefix.clone(), namespace_uri)]),
+            prefix,
+        }
+    }
+}
+
 /// An element parsed from the XMP.
 ///
 /// Contains identifiers and a value.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Hash)]
 pub struct XmpElement {
-    pub namespace: String,
-    pub prefix: String,
-    pub name: String,
-
+    pub ident: XmpIdent,
     pub value: XmpValue,
 }
 
@@ -115,25 +157,16 @@ pub enum XmpValueStructField {
     /// as opposed to one primitive value.
     ///
     /// In other words, the contained value isn't a primitive.
-    Element {
-        /// The field's name.
-        ident: String,
-
-        /// The field's namespace.
-        namespace: Option<String>,
-
-        /// The field's idents + value.
-        element: XmpElement,
-    },
+    Element(
+        /// The contained element, which allows children.
+        XmpElement,
+    ),
 
     /// Used when a contained value isn't recursive - it's just a
     /// primitive.
     Value {
-        /// The field's name.
-        ident: String,
-
-        /// The field's namespace.
-        namespace: Option<String>,
+        /// The field's identifying information.
+        ident: XmpIdent,
 
         /// The field's value.
         value: XmpValue,
@@ -142,18 +175,21 @@ pub enum XmpValueStructField {
 
 impl XmpValueStructField {
     /// Grabs a struct field's identifier.
-    pub fn ident(&self) -> &String {
+    pub fn name(&self) -> &String {
         match self {
-            XmpValueStructField::Element { ident, .. }
-            | XmpValueStructField::Value { ident, .. } => ident,
+            XmpValueStructField::Element(xmp_element) => &xmp_element.ident.name,
+            XmpValueStructField::Value { ident, value: _ } => &ident.name,
         }
     }
 
     /// Grabs a struct field's namespace.
     pub fn namespace(&self) -> Option<&String> {
         match self {
-            XmpValueStructField::Element { namespace, .. }
-            | XmpValueStructField::Value { namespace, .. } => namespace.as_ref(),
+            XmpValueStructField::Element(xmp_element) => {
+                xmp_element.ident.namespaces.get(&xmp_element.ident.prefix)
+            }
+
+            XmpValueStructField::Value { ident, value: _ } => ident.namespaces.get(&ident.prefix),
         }
     }
 }

--- a/raves_metadata_types/src/xmp/parse_types.rs
+++ b/raves_metadata_types/src/xmp/parse_types.rs
@@ -107,9 +107,8 @@ pub struct XmpKindStructFieldIdent {
 }
 
 impl XmpKindStructFieldIdent {
-    pub fn ns(&'static self) -> Option<&'static str> {
-        let CHANGE_THIS_TO_RETURN_STR_DIRECTLY = ();
-        Some(self.namespace)
+    pub fn ns(&'static self) -> &'static str {
+        self.namespace
     }
 
     pub fn name(&'static self) -> &'static str {

--- a/raves_metadata_types/src/xmp/parse_types.rs
+++ b/raves_metadata_types/src/xmp/parse_types.rs
@@ -88,6 +88,12 @@ pub enum XmpKind {
     ///
     /// In XML, this is `rdf:Alt`.
     Alternatives(&'static XmpKind),
+
+    /// A URI (or URL).
+    ///
+    /// In XML, it's represented by an `rdf:resource="{THE URI}"` attribute on
+    /// its element.
+    Uri,
 }
 
 /// Sorry for the long name, but what you need to know is that some struct

--- a/raves_metadata_types/src/xmp/parse_types.rs
+++ b/raves_metadata_types/src/xmp/parse_types.rs
@@ -96,45 +96,24 @@ pub enum XmpKind {
     Uri,
 }
 
-/// Sorry for the long name, but what you need to know is that some struct
-/// fields have a namespace URI requirement, whereas others don't specify
-/// it.
+/// A set of identifiers for a field.
 ///
-/// Ex: `ResourceRef` specifies that its namespace must be
-/// `http://ns.adobe.com/xap/1.0/sType/ResourceRef#`, while `FrameCount`
-/// makes no suggestion at all.
+/// Please note that the `prefix` field is "preferred", not required!
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
-pub enum XmpKindStructFieldIdent {
-    /// The field uses its parent's namespace.
-    ParentNs(&'static str),
-
-    /// The field doesn't have any namespace.
-    NoNs(&'static str),
-
-    /// This field requires a specific namespace!
-    Namespaced {
-        field_name: &'static str,
-        namespace: &'static str,
-    },
+pub struct XmpKindStructFieldIdent {
+    pub field_name: &'static str,
+    pub namespace: &'static str,
+    pub prefix: &'static str,
 }
 
 impl XmpKindStructFieldIdent {
     pub fn ns(&'static self) -> Option<&'static str> {
-        match self {
-            XmpKindStructFieldIdent::ParentNs(_) => None,
-            XmpKindStructFieldIdent::NoNs(_) => None,
-            XmpKindStructFieldIdent::Namespaced { namespace, .. } => Some(namespace),
-        }
+        let CHANGE_THIS_TO_RETURN_STR_DIRECTLY = ();
+        Some(self.namespace)
     }
 
     pub fn name(&'static self) -> &'static str {
-        match self {
-            XmpKindStructFieldIdent::ParentNs(name)
-            | XmpKindStructFieldIdent::NoNs(name)
-            | XmpKindStructFieldIdent::Namespaced {
-                field_name: name, ..
-            } => name,
-        }
+        self.field_name
     }
 }
 

--- a/raves_metadata_types/src/xmp/types.rs
+++ b/raves_metadata_types/src/xmp/types.rs
@@ -875,8 +875,8 @@ pub const TRACK: Kind = Kind::Struct({
         },
     ]
 });
-pub const URI: Kind = Kind::Simple(Prim::Text);
-pub const URL: Kind = Kind::Simple(Prim::Text);
+pub const URI: Kind = Kind::Uri;
+pub const URL: Kind = URI;
 pub const VERSION: Kind = Kind::Struct(&[
     Field {
         ident: Ident::Namespaced {

--- a/raves_metadata_types/src/xmp/types.rs
+++ b/raves_metadata_types/src/xmp/types.rs
@@ -11,57 +11,65 @@ use super::parse_types::{
 
 pub const AGENT_NAME: Kind = Kind::Simple(Prim::Text);
 pub const ANCESTOR: Kind = Kind::Struct(&[Field {
-    ident: Ident::Namespaced {
+    ident: Ident {
         field_name: "AncestorID",
         namespace: "http://ns.adobe.com/photoshop/1.0/",
+        prefix: "photoshop",
     },
     ty: &URI,
 }]);
 pub const BEAT_SPLICE_STRETCH: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "riseInDecibel",
             namespace: "http://ns.adobe.com/xmp/1.0/DynamicMedia/",
+            prefix: "xmpDm",
         },
         ty: &Kind::Simple(Prim::Real),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "riseInTimeDuration",
             namespace: "http://ns.adobe.com/xmp/1.0/DynamicMedia/",
+            prefix: "xmpDm",
         },
         ty: &TIME,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "useFileBeatsMarker",
             namespace: "http://ns.adobe.com/xmp/1.0/DynamicMedia/",
+            prefix: "xmpDm",
         },
         ty: &Kind::Simple(Prim::Boolean),
     },
 ]);
 pub const CFA_PATTERN: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/exif/1.0/";
+    const PREFERRED_PREFIX: &str = "exif";
 
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Columns",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Integer),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Rows",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Integer),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Values",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::OrderedArray(&Kind::Simple(Prim::Integer)),
         },
@@ -71,24 +79,27 @@ pub const CFA_PATTERN: Kind = Kind::Struct({
 pub const COLORANT: Kind = Kind::Union {
     always: &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "type",
                 namespace: "http://ns.adobe.com/xap/1.0/g/",
+                prefix: "xmpTPg",
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "swatchName",
                 namespace: "http://ns.adobe.com/xap/1.0/g/",
+                prefix: "xmpTPg",
             },
             ty: &Kind::Simple(Prim::Text),
         },
     ],
     discriminant: Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "mode",
             namespace: "http://ns.adobe.com/xap/1.0/g/",
+            prefix: "xmpTPg",
         },
         ty: &Kind::Simple(Prim::Text),
     },
@@ -99,23 +110,26 @@ pub const COLORANT: Kind = Kind::Union {
             "LAB",
             &[
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "A",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Integer),
                 },
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "B",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Integer),
                 },
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "L",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Real),
                 },
@@ -127,30 +141,34 @@ pub const COLORANT: Kind = Kind::Union {
             "CMWK",
             &[
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "black",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Real),
                 },
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "cyan",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Real),
                 },
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "magenta",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Real),
                 },
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "yellow",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Real),
                 },
@@ -162,23 +180,26 @@ pub const COLORANT: Kind = Kind::Union {
             "RGB",
             &[
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "blue",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Integer),
                 },
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "green",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Integer),
                 },
                 Field {
-                    ident: Ident::Namespaced {
+                    ident: Ident {
                         field_name: "red",
                         namespace: "http://ns.adobe.com/xap/1.0/g/",
+                        prefix: "xmpTPg",
                     },
                     ty: &Kind::Simple(Prim::Integer),
                 },
@@ -188,61 +209,70 @@ pub const COLORANT: Kind = Kind::Union {
 };
 pub const CONTACT_INFO: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/";
+    const PRERERRED_PREFIX: &str = "Iptc4xmpCore";
 
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "CiAdrExtadr",
                 namespace: NAMESPACE,
+                prefix: PRERERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "CiAdrCity",
                 namespace: NAMESPACE,
+                prefix: PRERERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "CiAdrRegion",
                 namespace: NAMESPACE,
+                prefix: PRERERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "CiAdrPcode",
                 namespace: NAMESPACE,
+                prefix: PRERERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "CiAdrCtry",
                 namespace: NAMESPACE,
+                prefix: PRERERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "CiTelWork",
                 namespace: NAMESPACE,
+                prefix: PRERERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "CiEmailWork",
                 namespace: NAMESPACE,
+                prefix: PRERERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "CiUrlWork",
                 namespace: NAMESPACE,
+                prefix: PRERERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
@@ -250,18 +280,21 @@ pub const CONTACT_INFO: Kind = Kind::Struct({
 });
 pub const CUE_POINT_PARAM: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/xmp/1.0/DynamicMedia/";
+    const PREFERRED_PREFIX: &str = "xmpDm";
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "key",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "value",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
@@ -269,26 +302,30 @@ pub const CUE_POINT_PARAM: Kind = Kind::Struct({
 });
 pub const DEVICE_SETTINGS: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/exif/1.0/";
+    const PREFERRED_PREFIX: &str = "exif";
 
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Columns",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Integer),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Rows",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Integer),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Values",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::OrderedArray(&Kind::Simple(Prim::Text)),
         },
@@ -296,63 +333,72 @@ pub const DEVICE_SETTINGS: Kind = Kind::Struct({
 });
 pub const DIMENSIONS: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "h",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Dimensions#",
+            prefix: "stDim",
         },
         ty: &Kind::Simple(Prim::Real),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "w",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Dimensions#",
+            prefix: "stDim",
         },
         ty: &Kind::Simple(Prim::Real),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "unit",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Dimensions#",
+            prefix: "stDim",
         },
         ty: &Kind::Simple(Prim::Text),
     },
 ]);
 pub const FLASH: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/exif/1.0/";
+    const PREFERRED_PREFIX: &str = "exif";
 
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Fired",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Boolean),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Function",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Boolean),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Mode",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Integer),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "RedEyeMode",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Boolean),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Return",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Integer),
         },
@@ -360,58 +406,66 @@ pub const FLASH: Kind = Kind::Struct({
 });
 pub const FONT: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "childFontFiles",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Font#",
+            prefix: "stFnt",
         },
         ty: &Kind::OrderedArray(&Kind::Simple(Prim::Text)),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "composite",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Font#",
+            prefix: "stFnt",
         },
         ty: &Kind::Simple(Prim::Boolean),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "fontFace",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Font#",
+            prefix: "stFnt",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "fontFamily",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Font#",
+            prefix: "stFnt",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "fontFileName",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Font#",
+            prefix: "stFnt",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "fontName",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Font#",
+            prefix: "stFnt",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "fontType",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Font#",
+            prefix: "stFnt",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "versionString",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Font#",
+            prefix: "stFnt",
         },
         ty: &Kind::Simple(Prim::Text),
     },
@@ -430,23 +484,26 @@ pub const FRAME_RATE: Kind = Kind::StructUnspecifiedFields {
 pub const GUID: Kind = Kind::Simple(Prim::Text);
 pub const JOB: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "id",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Job#",
+            prefix: "stJob",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "name",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Job#",
+            prefix: "stJob",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "url",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Job#",
+            prefix: "stJob",
         },
         ty: &URL,
     },
@@ -457,18 +514,22 @@ pub const JOB: Kind = Kind::Struct(&[
 pub const LANGUAGE_ALTERNATIVE: Kind = Kind::Alternatives(&Kind::Simple(Prim::Text));
 pub const LAYER: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/photoshop/1.0/";
+    const PREFERRED_PREFIX: &str = "photoshop";
+
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "LayerName",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "LayerText",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
@@ -477,46 +538,54 @@ pub const LAYER: Kind = Kind::Struct({
 pub const LOCALE: Kind = Kind::Simple(Prim::Text);
 pub const MEDIA: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/xmp/1.0/DynamicMedia/";
+    const PREFERRED_PREFIX: &str = "xmpDM";
+
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "duration",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &TIME,
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "managed",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Boolean),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "path",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &URI,
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "startTime",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &TIME,
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "track",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "webStatement",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &URI,
         },
@@ -524,81 +593,94 @@ pub const MEDIA: Kind = Kind::Struct({
 });
 pub const MARKER: Kind = Kind::Struct({
     pub const NAMESPACE: &str = "http://ns.adobe.com/xmp/1.0/DynamicMedia/";
+    const PREFERRED_PREFIX: &str = "xmpDM";
+
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "comment",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "cuePointParams",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::OrderedArray(&CUE_POINT_PARAM),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "cuePointType",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "duration",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &FRAME_COUNT,
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "location",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &URI,
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "name",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "probability",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Real),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "speaker",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "startTime",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &FRAME_COUNT,
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "target",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "type",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
@@ -612,33 +694,38 @@ pub const MIME_TYPE: Kind = Kind::Simple(Prim::Text);
 /// parse Exif.
 pub const OECF_SFR: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/exif/1.0/";
+    const PREFERRED_PREFIX: &str = "exif";
 
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Columns",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Integer),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Names", // column names probably woulda been better lol
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::OrderedArray(&Kind::Simple(Prim::Text)),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Rows",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Integer),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "Values",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::OrderedArray(&RATIONAL),
         },
@@ -646,18 +733,22 @@ pub const OECF_SFR: Kind = Kind::Struct({
 });
 pub const PROJECT_LINK: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/xmp/1.0/DynamicMedia/";
+    const PREFERRED_PREFIX: &str = "xmpDM";
+
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "path",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &URI,
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "type",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
@@ -666,45 +757,51 @@ pub const PROJECT_LINK: Kind = Kind::Struct({
 pub const PROPER_NAME: Kind = Kind::Simple(Prim::Text);
 pub const RATIONAL: Kind = Kind::Simple(Prim::Text);
 pub const RESAMPLE_STRETCH: Kind = Kind::Struct(&[Field {
-    ident: Ident::Namespaced {
+    ident: Ident {
         field_name: "quality",
         namespace: "http://ns.adobe.com/xmp/1.0/DynamicMedia/",
+        prefix: "xmpDM",
     },
     ty: &Kind::Simple(Prim::Text),
 }]);
 pub const RESOURCE_REF: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "documentID",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceRef#",
+            prefix: "stRef",
         },
         ty: &GUID,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "filePath",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceRef#",
+            prefix: "stRef",
         },
         ty: &URI,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "instanceID",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceRef#",
+            prefix: "stRef",
         },
         ty: &GUID,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "renditionClass",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceRef#",
+            prefix: "stRef",
         },
         ty: &RENDITION_CLASS,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "renditionParam",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceRef#",
+            prefix: "stRef",
         },
         ty: &Kind::Simple(Prim::Text),
     },
@@ -712,131 +809,150 @@ pub const RESOURCE_REF: Kind = Kind::Struct(&[
 pub const RENDITION_CLASS: Kind = Kind::Simple(Prim::Text);
 pub const RESOURCE_EVENT: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "action",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#",
+            prefix: "stEvt",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "changed",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#",
+            prefix: "stEvt",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "instanceID",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#",
+            prefix: "stEvt",
         },
         ty: &GUID,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "parameters",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#",
+            prefix: "stEvt",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "softwareAgent",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#",
+            prefix: "stEvt",
         },
         ty: &AGENT_NAME,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "when",
             namespace: "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#",
+            prefix: "stEvt",
         },
         ty: &Kind::Simple(Prim::Date),
     },
 ]);
 pub const THUMBNAIL: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "format",
             namespace: "http://ns.adobe.com/xap/1.0/g/img/",
+            prefix: "xmpGImg",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "height",
             namespace: "http://ns.adobe.com/xap/1.0/g/img/",
+            prefix: "xmpGImg",
         },
         ty: &Kind::Simple(Prim::Integer),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "width",
             namespace: "http://ns.adobe.com/xap/1.0/g/img/",
+            prefix: "xmpGImg",
         },
         ty: &Kind::Simple(Prim::Integer),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "image",
             namespace: "http://ns.adobe.com/xap/1.0/g/img/",
+            prefix: "xmpGImg",
         },
         ty: &Kind::Simple(Prim::Text),
     },
 ]);
 pub const TIME: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "scale",
             namespace: "http://ns.adobe.com/xmp/1.0/DynamicMedia/",
+            prefix: "xmpDM",
         },
         ty: &RATIONAL,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "value",
             namespace: "http://ns.adobe.com/xmp/1.0/DynamicMedia/",
+            prefix: "xmpDM",
         },
         ty: &Kind::Simple(Prim::Integer),
     },
 ]);
 pub const TIMECODE: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "timeFormat",
             namespace: "http://ns.adobe.com/xmp/1.0/DynamicMedia/",
+            prefix: "xmpDM",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "timeValue",
             namespace: "http://ns.adobe.com/xmp/1.0/DynamicMedia/",
+            prefix: "xmpDM",
         },
         ty: &Kind::Simple(Prim::Text),
     },
 ]);
 pub const TIME_SCALE_STRETCH: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/xmp/1.0/DynamicMedia/";
+    const PREFERRED_PREFIX: &str = "xmpDM";
+
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "frameOverlappingPercentage",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Real),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "frameSize",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Real),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "quality",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
@@ -844,32 +960,38 @@ pub const TIME_SCALE_STRETCH: Kind = Kind::Struct({
 });
 pub const TRACK: Kind = Kind::Struct({
     const NAMESPACE: &str = "http://ns.adobe.com/xmp/1.0/DynamicMedia/";
+    const PREFERRED_PREFIX: &str = "xmpDM";
+
     &[
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "frameRate",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &FRAME_RATE,
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "markers",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::OrderedArray(&MARKER),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "trackName",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
         Field {
-            ident: Ident::Namespaced {
+            ident: Ident {
                 field_name: "trackType",
                 namespace: NAMESPACE,
+                prefix: PREFERRED_PREFIX,
             },
             ty: &Kind::Simple(Prim::Text),
         },
@@ -879,37 +1001,42 @@ pub const URI: Kind = Kind::Uri;
 pub const URL: Kind = URI;
 pub const VERSION: Kind = Kind::Struct(&[
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "comments",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Version#",
+            prefix: "stVer",
         },
         ty: &Kind::Simple(Prim::Text),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "event",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Version#",
+            prefix: "stVer",
         },
         ty: &RESOURCE_EVENT,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "modifier",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Version#",
+            prefix: "stVer",
         },
         ty: &PROPER_NAME,
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "modifyDate",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Version#",
+            prefix: "stVer",
         },
         ty: &Kind::Simple(Prim::Date),
     },
     Field {
-        ident: Ident::Namespaced {
+        ident: Ident {
             field_name: "version",
             namespace: "http://ns.adobe.com/xap/1.0/sType/Version#",
+            prefix: "stVer",
         },
         ty: &Kind::Simple(Prim::Text),
     },


### PR DESCRIPTION
## Description

I'm adding write support for XMP! This'll let me implement write support for each of the metadata providers as well -- just need a way to go from the intermediate representation into the mainstream repr.

## Changes

- Change XMP types for closer adherence to standard
- Add XMP -> XML writer
- Test the XMP writer

## Checklist

- [x] Implement a URI type
- [x] Create a writer
- [x] Fully test the writer